### PR TITLE
Move RichGroup and RichCommand out of rich_click.py

### DIFF
--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -11,8 +11,8 @@ __version__ = "1.2.2.dev0"
 from click import *
 from click import group as click_group
 from click import command as click_command
-from .rich_click import RichGroup
-from .rich_click import RichCommand
+from rich_click.rich_group import RichGroup
+from rich_click.rich_command import RichCommand
 
 
 def group(*args, cls=RichGroup, **kwargs):

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -11,6 +11,7 @@ class RichCommand(click.Command):
     Inherits click.Command and overrides help and error methods
     to print richly formatted output.
     """
+
     standalone_mode = False
 
     def main(self, *args, standalone_mode=True, **kwargs):

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -1,0 +1,31 @@
+import sys
+
+import click
+
+from rich_click.rich_click import rich_format_error, rich_abort_error, rich_format_help
+
+
+class RichCommand(click.Command):
+    """Richly formatted click Command.
+
+    Inherits click.Command and overrides help and error methods
+    to print richly formatted output.
+    """
+    standalone_mode = False
+
+    def main(self, *args, standalone_mode=True, **kwargs):
+        try:
+            return super().main(*args, standalone_mode=False, **kwargs)
+        except click.ClickException as e:
+            if not standalone_mode:
+                raise
+            rich_format_error(e)
+            sys.exit(e.exit_code)
+        except click.exceptions.Abort as e:
+            if not standalone_mode:
+                raise
+            rich_abort_error()
+            sys.exit(1)
+
+    def format_help(self, ctx, formatter):
+        rich_format_help(self, ctx, formatter)

--- a/src/rich_click/rich_group.py
+++ b/src/rich_click/rich_group.py
@@ -1,0 +1,33 @@
+import sys
+
+import click
+
+from rich_click.rich_command import RichCommand
+from rich_click.rich_click import rich_format_error, rich_abort_error, rich_format_help
+
+
+class RichGroup(click.Group):
+    """Richly formatted click Group.
+
+    Inherits click.Group and overrides help and error methods
+    to print richly formatted output.
+    """
+    command_class = RichCommand
+    group_class = type
+
+    def main(self, *args, standalone_mode=True, **kwargs):
+        try:
+            return super().main(*args, standalone_mode=False, **kwargs)
+        except click.ClickException as e:
+            if not standalone_mode:
+                raise
+            rich_format_error(e)
+            sys.exit(e.exit_code)
+        except click.exceptions.Abort as e:
+            if not standalone_mode:
+                raise
+            rich_abort_error()
+            sys.exit(1)
+
+    def format_help(self, ctx, formatter):
+        rich_format_help(self, ctx, formatter)

--- a/src/rich_click/rich_group.py
+++ b/src/rich_click/rich_group.py
@@ -12,6 +12,7 @@ class RichGroup(click.Group):
     Inherits click.Group and overrides help and error methods
     to print richly formatted output.
     """
+
     command_class = RichCommand
     group_class = type
 


### PR DESCRIPTION
First of a couple refactorings that are coming up.
This refactoring:
- Removes local imports. It's generally more preferred to use absolute imports.
- I moved the classes out of rich_click.py. This made the rich_click.py unnecessarily large..
- Moved the creation of the console into a function, as it's used all over the place.

I think to tune this file down more, we might consider moving all rich specific tools to a file called `rich_utils` and moving the click items into `click_utils`. 