### PR TITLE
Add PEP 561 Compatiblity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 1.2.2.dev0
 
+- Mark PEP 561 Compatibility [[PR41](https://github.com/ewels/rich-click/pull/41)]
 - Add typing information [[PR39](https://github.com/ewels/rich-click/pull/39)]
 - Refactor RichCommand and RichGroup out of rich_click [[PR38](https://github.com/ewels/rich-click/pull/39)]
 - Change metavar overflow to `fold`, so that large numbers of choices flow onto new lines instead of being truncated with an ellipsis [[#33](https://github.com/ewels/rich-click/issues/33)]

--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,5 @@ setup(
         "rich>=10",
         "importlib-metadata; python_version < '3.8'",
     ],
+    package_data={"rich-click": ["py.typed"]},
 )

--- a/src/rich_click/py.typed
+++ b/src/rich_click/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. rich-click uses inline types.


### PR DESCRIPTION
Hi there 👋 

I just saw https://github.com/ewels/rich-click/pull/39 and thought it might be useful to add a `py.typed` file. This allows downstream projects to use the type hints for things like PyCharm, mypy, pytype etc.

Without this file, mypy currently complains in projects that use rich-click:

```
error: Skipping analyzing "rich_click": module is installed, but missing library stubs or py.typed marker
```

The `py.typed` file makes rich-click [PEP-561 compatible](https://www.python.org/dev/peps/pep-0561), and allows the inline types to be used. See [here](https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/) for further explanation.