### PR TITLE
Add MacPorts Distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 1.2.2.dev0
 
+- Distribution now available via MacPorts [[PR42](https://github.com/ewels/rich-click/pull/42)]
 - Add typing information [[PR39](https://github.com/ewels/rich-click/pull/39)]
 - Refactor RichCommand and RichGroup out of rich_click [[PR38](https://github.com/ewels/rich-click/pull/39)]
 - Change metavar overflow to `fold`, so that large numbers of choices flow onto new lines instead of being truncated with an ellipsis [[#33](https://github.com/ewels/rich-click/issues/33)]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Just set up conda to use conda-forge (see [docs](https://conda-forge.org/docs/us
 conda install rich-click
 ```
 
+Users on macOS can install `rich-click` via [MacPorts](https://ports.macports.org/port/py-rich-click/).
+
+```bash
+sudo port install py-rich-click
+```
+
 ## Usage
 
 ### Import as click


### PR DESCRIPTION
I've found this project really useful, so I thought that I could help it most by adding it to [MacPorts](https://www.macports.org/). You can find it's project page [here](https://ports.macports.org/port/py-rich-click/), and it can be installed on macOS by running the following:

```
sudo port install py-rich-click
```

Finally, thank you so much @ewels for keeping this amazing project going. It has been such a useful library and I really appreciate the work you've put into it. 👍 