### PR TITLE
Override the class in addition to the decorator.

### DIFF
--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -5,7 +5,7 @@ The intention is to provide attractive help output from click, formatted with ri
 customisation required.
 """
 
-__version__ = "1.2.2.dev0"
+__version__ = "1.2.2.dev1"
 
 from typing import TYPE_CHECKING
 

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -19,6 +19,8 @@ from rich.text import Text
 
 from rich_click import command as rich_command
 from rich_click import group as rich_group
+from rich_click import RichCommand
+from rich_click import RichGroup
 from rich_click.rich_click import (
     ALIGN_ERRORS_PANEL,
     ERRORS_PANEL_TITLE,
@@ -123,6 +125,8 @@ def main(args: Optional[List[str]] = None) -> Any:
     # patch click before importing the program function
     click.group = rich_group
     click.command = rich_command
+    click.Group = RichGroup
+    click.Command = RichCommand
     # import the program function
     module = import_module(module_path)
     function = getattr(module, function_name)

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -19,8 +19,7 @@ from rich.text import Text
 
 from rich_click import command as rich_command
 from rich_click import group as rich_group
-from rich_click import RichCommand
-from rich_click import RichGroup
+from rich_click import RichCommand, RichGroup
 from rich_click.rich_click import (
     ALIGN_ERRORS_PANEL,
     ERRORS_PANEL_TITLE,


### PR DESCRIPTION
This PR fixes an issue wherein many popular libraries' CLIs (such as Celery and Flask) do not work as intended with `rich-click [command]`.

The reason why the current approach doesn't work is because these libraries opt to subclass `click.Group` instead of using decorators for the entrypoints `flask` and `celery`. In these cases, patching `click.Command` instead of `click.command` does the trick.

However, it is still necessary to patch the decorators in other cases, e.g. `rich-command flask --help` needs `click.Group` (class) to be patched, but `rich-command flask run --help` needs `click.command` (decorator) to be patched.