### PR TITLE
Make `_make_rich_rext` remove text indentations with `inspect.cleandoc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bumped minimum version of `rich` from `10` to `10.7.0` (when `Group` was introduced)
 - Refactored CLI's patching functionality to support `from rich_click.cli import patch`.
+- Make `_make_rich_rext` remove text indentations using `inspect.cleandoc`.
 
 ## Version 1.3.0 (2022-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bumped minimum version of `rich` from `10` to `10.7.0` (when `Group` was introduced)
 - Refactored CLI's patching functionality to support `from rich_click.cli import patch`.
-- Make `_make_rich_rext` remove text indentations using `inspect.cleandoc`.
+- Make `_make_rich_rext` remove text indentations using `inspect.cleandoc` [[#55](https://github.com/ewels/rich-click/issues/55)]
 
 ## Version 1.3.0 (2022-03-29)
 

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 from typing import Dict, List, Optional, Union
 
@@ -114,7 +115,7 @@ def _get_rich_console() -> Console:
 
 
 def _make_rich_rext(text: str, style: str = "") -> Union[rich.markdown.Markdown, rich.text.Text]:
-    """Take a string and return styled text.
+    """Take a string, remove indentations, and return styled text.
 
     By default, return the text as a Rich Text with the request style.
     If USE_RICH_MARKUP is True, also parse the text for Rich markup strings.
@@ -130,6 +131,8 @@ def _make_rich_rext(text: str, style: str = "") -> Union[rich.markdown.Markdown,
     Returns:
         MarkdownElement or Text: Styled text object
     """
+    # Remove indentations from input text
+    text = inspect.cleandoc(text)
     if USE_MARKDOWN:
         if USE_MARKDOWN_EMOJI:
             text = Emoji.replace(text)


### PR DESCRIPTION
This should fix https://github.com/ewels/rich-click/issues/55 (I haven't tested it yet!). @ewels, do you think that `inspect.cleandoc` should be optional (`True` by default)?