### PR TITLE
Make `_make_command_help` remove text indentations with `inspect.cleandoc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog: rich-click
 
+## Version 1.3.2dev
+
+- Fix missed indentation issue in subcommand help text with `inspect.cleandoc` [[#67](https://github.com/ewels/rich-click/pull/67)]
+
 ## Version 1.3.1 (2022-05-15)
 
 - Bumped minimum version of `rich` from `10` to `10.7.0` (when `Group` was introduced)

--- a/examples/click/01_simple.py
+++ b/examples/click/01_simple.py
@@ -32,9 +32,10 @@ def cli(debug):
     show_default=True,
     help="Type of file to sync",
 )
-@click.option("--all", is_flag=True, help="Sync all the things?")
+@click.option("--all", is_flag=True)
 def sync(type, all):
-    """Synchronise all your files between two places."""
+    """Synchronise all your files between two places.
+    Example command that doesn't do much except print to the terminal."""
     print("Syncing")
 
 

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -276,7 +276,7 @@ def _make_command_help(help_text: str) -> Union[rich.text.Text, rich.markdown.Ma
     Returns:
         Text or Markdown: Styled object
     """
-    paragraphs = help_text.split("\n\n")
+    paragraphs = inspect.cleandoc(help_text).split("\n\n")
     # Remove single linebreaks
     if not USE_MARKDOWN and not paragraphs[0].startswith("\b"):
         paragraphs[0] = paragraphs[0].replace("\n", " ")


### PR DESCRIPTION
My last PR didn't fix https://github.com/ewels/rich-click/issues/55 properly. The command help texts were not being sanitized.

I tested this PR and this time it really fixes the issue.