### PR TITLE
Fix package syntax in setup.py for py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
         "typer": "typer>=0.4",
         "dev": "pre-commit",
     },
-    package_data={"rich-click": ["py.typed"]},
+    package_data={"rich_click": ["py.typed"]},
 )


### PR DESCRIPTION
1074477 in #41 introduced the py.typed file, for marking the package as containing typehints as part of PEP 561, however the package name is incorrect and as such is not included in built wheels.

This PR should fix the issue.

Before:
```
adding 'rich_click/__init__.py'
adding 'rich_click/__main__.py'
adding 'rich_click/cli.py'
adding 'rich_click/rich_click.py'
adding 'rich_click/rich_command.py'
adding 'rich_click/rich_group.py'
adding 'rich_click/typer.py'
```

After:
```
adding 'rich_click/__init__.py'
adding 'rich_click/__main__.py'
adding 'rich_click/cli.py'
adding 'rich_click/py.typed'
adding 'rich_click/rich_click.py'
adding 'rich_click/rich_command.py'
adding 'rich_click/rich_group.py'
adding 'rich_click/typer.py'
```