### PR TITLE
Fix return values print (#63)

### DIFF
--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -16,7 +16,9 @@ class RichCommand(click.Command):
 
     def main(self, *args, standalone_mode: bool = True, **kwargs):
         try:
-            return super().main(*args, standalone_mode=False, **kwargs)
+            rv = super().main(*args, standalone_mode=False, **kwargs)
+            if not standalone_mode:
+                return rv
         except click.ClickException as e:
             if not standalone_mode:
                 raise


### PR DESCRIPTION
@ewels What do you think of this as a fix to #63?

I think you probably want to run `super().main` (in *RichCommand.main*) with `standalone_mode=False` so that *click* doesn't exit or print error message. However, once `BaseCommand.main` has run and you have the return value, you don't need to pass it on unless `RichCommand.main` itself was called with *standalone_mode* set to *False*.