### PR TITLE
Update build

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -14,15 +14,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: "3.8"
 
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel build
-          pip install .
 
       - name: Build the distribution
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Publish to PyPI
         if: github.repository == 'ewels/rich-click'

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Check out source-code repository
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
       - uses: pre-commit/action@v2.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,4 +36,7 @@ console_scripts =
 [options.packages.find]
 where = src
 
+[options.package_data]
+* = py.typed
+
 # Dependencies are in setup.py for GitHub's dependency graph.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup
 
 setup(
-    name="rich-click",
     install_requires=[
         "click>=7",
         "rich>=10.7.0",
@@ -11,5 +10,4 @@ setup(
         "typer": "typer>=0.4",
         "dev": "pre-commit",
     },
-    package_data={"rich_click": ["py.typed"]},
 )


### PR DESCRIPTION
* Use `python -m build` instead of invoking `setup.py`, in accordance with "SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools."
* Update Action versions
* Minimize what is included in `setup.py` (only the deps, to get in the Dependency Graph)