### PR TITLE
skipping metavars for flags

### DIFF
--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -266,8 +266,8 @@ def _get_parameter_help(param: Union[click.Option, click.Argument], ctx: click.C
         # Do it ourselves if this is a positional argument
         if isinstance(param, click.core.Argument) and re.match(rf"\[?{param.name.upper()}]?", metavar_str):
             metavar_str = param.type.name.upper()
-        # Skip if param is boolean, is a positional argument, or if it's a flag
-        if not (metavar_str == "BOOLEAN" or isinstance(param, click.core.Argument) or param.is_flag):
+        # Attach metavar if param is a positional argument, or if it is a non boolean and non flag option
+        if isinstance(param, click.core.Argument) or (metavar_str != "BOOLEAN" and not param.is_flag):
             metavar_str = metavar_str.replace("[", "").replace("]", "")
             items.append(
                 Text(
@@ -445,8 +445,8 @@ def rich_format_help(
             if isinstance(param, click.core.Argument) and re.match(rf"\[?{param.name.upper()}]?", metavar_str):
                 metavar_str = param.type.name.upper()
 
-            # Skip if param is boolean, is a positional argument, or if it's a flag
-            if not (metavar_str == "BOOLEAN" or isinstance(param, click.core.Argument) or param.is_flag):
+            # Attach metavar if param is a positional argument, or if it is a non boolean and non flag option
+            if isinstance(param, click.core.Argument) or (metavar_str != "BOOLEAN" and not param.is_flag):
                 metavar.append(metavar_str)
 
             # Range - from

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -266,8 +266,8 @@ def _get_parameter_help(param: Union[click.Option, click.Argument], ctx: click.C
         # Do it ourselves if this is a positional argument
         if isinstance(param, click.core.Argument) and re.match(rf"\[?{param.name.upper()}]?", metavar_str):
             metavar_str = param.type.name.upper()
-        # Skip if param is boolean (and isn't a positional argument), or if it's a flag
-        if not ((metavar_str == "BOOLEAN" and not isinstance(param, click.core.Argument)) or param.is_flag):
+        # Skip if param is boolean, is a positional argument, or if it's a flag
+        if not (metavar_str == "BOOLEAN" or isinstance(param, click.core.Argument) or param.is_flag):
             metavar_str = metavar_str.replace("[", "").replace("]", "")
             items.append(
                 Text(
@@ -445,8 +445,8 @@ def rich_format_help(
             if isinstance(param, click.core.Argument) and re.match(rf"\[?{param.name.upper()}]?", metavar_str):
                 metavar_str = param.type.name.upper()
 
-            # Skip if param is boolean (and isn't a positional argument), or if it's a flag
-            if not ((metavar_str == "BOOLEAN" and not isinstance(param, click.core.Argument)) or param.is_flag):
+            # Skip if param is boolean, is a positional argument, or if it's a flag
+            if not (metavar_str == "BOOLEAN" or isinstance(param, click.core.Argument) or param.is_flag):
                 metavar.append(metavar_str)
 
             # Range - from

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -266,8 +266,8 @@ def _get_parameter_help(param: Union[click.Option, click.Argument], ctx: click.C
         # Do it ourselves if this is a positional argument
         if isinstance(param, click.core.Argument) and re.match(rf"\[?{param.name.upper()}]?", metavar_str):
             metavar_str = param.type.name.upper()
-        # Skip booleans
-        if metavar_str != "BOOLEAN" or isinstance(param, click.core.Argument):
+        # Skip if param is boolean (and isn't a positional argument), or if it's a flag
+        if not ((metavar_str == "BOOLEAN" and not isinstance(param, click.core.Argument)) or param.is_flag):
             metavar_str = metavar_str.replace("[", "").replace("]", "")
             items.append(
                 Text(
@@ -445,8 +445,8 @@ def rich_format_help(
             if isinstance(param, click.core.Argument) and re.match(rf"\[?{param.name.upper()}]?", metavar_str):
                 metavar_str = param.type.name.upper()
 
-            # Skip booleans and choices (handled above)
-            if metavar_str != "BOOLEAN" or isinstance(param, click.core.Argument):
+            # Skip if param is boolean (and isn't a positional argument), or if it's a flag
+            if not ((metavar_str == "BOOLEAN" and not isinstance(param, click.core.Argument)) or param.is_flag):
                 metavar.append(metavar_str)
 
             # Range - from


### PR DESCRIPTION
See this example script for click feature switches (adapted from https://click.palletsprojects.com/en/8.1.x/options/#feature-switches)
```python
import sys
import rich_click as click


@click.command()
@click.option("--upper", "transformation", flag_value="upper", default=True, help="upper case")
@click.option("--lower", "transformation", flag_value="lower", help="lower case")
def info(transformation):
    click.echo(getattr(sys.platform, transformation)())


if __name__ == "__main__":
    info()

```
Before, `rich-click` would print this as help text:
```
 Usage: test.py [OPTIONS]                                 
                                                          
╭─ Options ──────────────────────────────────────────────╮
│ --upper    TEXT  upper case                            │
│ --lower    TEXT  lower case                            │
│ --help           Show this message and exit.           │
╰────────────────────────────────────────────────────────╯
```
but there is no input for the `--upper` and `--lower` flags. I believe all flags should not print metavars information. With this fix, we get:
```
 Usage: test.py [OPTIONS]                                 
                                                          
╭─ Options ──────────────────────────────────────────────╮
│ --upper      upper case                                │
│ --lower      lower case                                │
│ --help       Show this message and exit.               │
╰────────────────────────────────────────────────────────╯
```