### PR TITLE
Adding `STYLE_COMMAND`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.6.2dev (2023-03-28)
 
-- Add new style option STYLE_COMMAND
+- Add new style option `STYLE_COMMAND`
 
 ## Version 1.6.1 (2023-01-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog: rich-click
 
+## Version 1.6.2dev (2023-03-28)
+
+- Add new style option STYLE_COMMAND
+
 ## Version 1.6.1 (2023-01-19)
 
 - Don't show metavars for [feature switch](https://click.palletsprojects.com/en/8.1.x/options/#feature-switches) options [[#100](https://github.com/ewels/rich-click/issues/100)] (@likewei92)

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Here is the full list of config options:
 # Default styles
 STYLE_OPTION = "bold cyan"
 STYLE_ARGUMENT = "bold cyan"
+STYLE_COMMAND = "bold cyan"
 STYLE_SWITCH = "bold green"
 STYLE_METAVAR = "bold yellow"
 STYLE_METAVAR_APPEND = "dim yellow"

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -27,6 +27,7 @@ except ImportError:
 # Default styles
 STYLE_OPTION = "bold cyan"
 STYLE_ARGUMENT = "bold cyan"
+STYLE_COMMAND = "bold cyan"
 STYLE_SWITCH = "bold green"
 STYLE_METAVAR = "bold yellow"
 STYLE_METAVAR_APPEND = "dim yellow"
@@ -125,6 +126,7 @@ def _get_rich_console() -> Console:
             {
                 "option": STYLE_OPTION,
                 "argument": STYLE_ARGUMENT,
+                "command": STYLE_COMMAND,
                 "switch": STYLE_SWITCH,
                 "metavar": STYLE_METAVAR,
                 "metavar_sep": STYLE_METAVAR_SEPARATOR,
@@ -362,7 +364,6 @@ def rich_format_help(
 
     # Print command / group help if we have some
     if obj.help:
-
         # Print with some padding
         console.print(
             Padding(
@@ -378,7 +379,6 @@ def rich_format_help(
     argument_group_options = []
 
     for param in obj.get_params(ctx):
-
         # Skip positional arguments - they don't have opts or helptext and are covered in usage
         # See https://click.palletsprojects.com/en/8.0.x/documentation/#documenting-arguments
         if isinstance(param, click.core.Argument) and not SHOW_ARGUMENTS:
@@ -408,10 +408,8 @@ def rich_format_help(
 
     # Print each option group panel
     for option_group in option_groups:
-
         options_rows = []
         for opt in option_group.get("options", []):
-
             # Get the param
             for param in obj.get_params(ctx):
                 if any([opt in param.opts]):
@@ -565,7 +563,7 @@ def rich_format_help(
                 **t_styles,
             )
             # Define formatting in first column, as commands don't match highlighter regex
-            commands_table.add_column(style="bold cyan", no_wrap=True)
+            commands_table.add_column(style=STYLE_COMMAND, no_wrap=True)
             for command in cmd_group.get("commands", []):
                 # Skip if command does not exist
                 if command not in obj.list_commands(ctx):


### PR DESCRIPTION
As a user of `rich_click`, I'd like to have the option to restyle commands in the command table. Commands currently [have a hard-coded `bold cyan` style](https://github.com/ewels/rich-click/blob/main/src/rich_click/rich_click.py#L568) which cannot be reconfigured.

This PR introduces `STYLE_COMMAND`, a new option exposed to user configuration. It's currently defaulted to `"bold cyan"` to preserve consistent styling.

Before:

<img width="475" alt="image" src="https://user-images.githubusercontent.com/272026/228232594-647ce095-bc1f-4fa0-98d8-278552cac90c.png">

After:

<img width="576" alt="image" src="https://user-images.githubusercontent.com/272026/228232792-b992db19-0c9b-48d4-adaa-f77eef248f37.png">
