### PR TITLE
Deprecate click 7.x support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
         "rich>=10.7.0",
         "importlib-metadata; python_version < '3.8'",
         "typing_extensions",
+        "packaging",
     ],
     extras_require={
         "dev": ["pre-commit", "pytest", "flake8", "flake8-docstrings", "pytest-cov"],

--- a/src/rich_click/_compat_click.py
+++ b/src/rich_click/_compat_click.py
@@ -1,5 +1,17 @@
-from distutils.version import LooseVersion
+import warnings
 
 import click
 
-CLICK_IS_BEFORE_VERSION_8X = LooseVersion(click.__version__) < LooseVersion("8.0.0")
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=DeprecationWarning)
+    # TODO: Remove use of distutils.version.LooseVersion (distutils.version is deprecated).
+    from distutils.version import LooseVersion
+
+    CLICK_IS_BEFORE_VERSION_8X = LooseVersion(click.__version__) < LooseVersion("8.0.0")
+
+if CLICK_IS_BEFORE_VERSION_8X:
+    warnings.warn(
+        "rich-click support for click 7.x is deprecated and will be removed soon."
+        " Please upgrade click to a newer version.",
+        DeprecationWarning,
+    )

--- a/src/rich_click/_compat_click.py
+++ b/src/rich_click/_compat_click.py
@@ -1,15 +1,12 @@
-import warnings
-
 import click
+from packaging import version
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", category=DeprecationWarning)
-    # TODO: Remove use of distutils.version.LooseVersion (distutils.version is deprecated).
-    from distutils.version import LooseVersion
+CLICK_IS_BEFORE_VERSION_8X = version.parse(click.__version__) < version.parse("8.0.0")
 
-    CLICK_IS_BEFORE_VERSION_8X = LooseVersion(click.__version__) < LooseVersion("8.0.0")
 
 if CLICK_IS_BEFORE_VERSION_8X:
+    import warnings
+
     warnings.warn(
         "rich-click support for click 7.x is deprecated and will be removed soon."
         " Please upgrade click to a newer version.",

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -26,7 +26,7 @@ class RichCommand(click.Command):
         Docs reference: https://click.palletsprojects.com/
         """
         super().__init__(*args, **kwargs)
-        self._formatter: Optional[RichHelpFormatter] = None
+        self._formatter: Optional[RichHelpFormatter] = None  # type: ignore[annotation-unchecked]
 
     @property
     def console(self):

--- a/src/rich_click/rich_group.py
+++ b/src/rich_click/rich_group.py
@@ -28,7 +28,7 @@ class RichGroup(click.Group):
         Docs reference: https://click.palletsprojects.com/
         """
         super().__init__(*args, **kwargs)
-        self._formatter: Optional[RichHelpFormatter] = None
+        self._formatter: Optional[RichHelpFormatter] = None  # type: ignore[annotation-unchecked]
 
     @property
     def console(self):

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,19 +1,18 @@
-from distutils.version import LooseVersion
-from importlib.metadata import version
+from importlib import metadata  # type: ignore
 from typing import Optional, Type
 
 import click
 import pytest
 from click import UsageError
 from conftest import AssertRichFormat, AssertStr, InvokeCli
+from packaging import version
 from rich.console import Console
 
-import rich_click.rich_click as rc
 from rich_click import command, rich_config, RichContext, RichHelpConfiguration
 from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
 from rich_click.rich_command import RichCommand
 
-rich_version = LooseVersion(version("rich"))
+rich_version = version.parse(metadata.version("rich"))
 
 
 @pytest.mark.parametrize(
@@ -31,7 +30,7 @@ rich_version = LooseVersion(version("rich"))
             None,
             id="test markdown",
             marks=pytest.mark.skipif(
-                rich_version < LooseVersion("13.0.0"), reason="Markdown h1 borders are different."
+                rich_version < version.parse("13.0.0"), reason="Markdown h1 borders are different."
             ),
         ),
         pytest.param("metavars_default", "--help", None, None, id="test metavars default"),
@@ -128,7 +127,7 @@ rich_version = LooseVersion(version("rich"))
             rich_config(help_config=RichHelpConfiguration(use_markdown=True)),
             id="test markdown with rich_config",
             marks=pytest.mark.skipif(
-                rich_version < LooseVersion("13.0.0"), reason="Markdown h1 borders are different."
+                rich_version < version.parse("13.0.0"), reason="Markdown h1 borders are different."
             ),
         ),
         pytest.param(


### PR DESCRIPTION
Resolves #116

Mostly self-explanatory PR.

I did not add TODO comments because all the parts of the code that need to be changed are easy enough to find in the code (basically, anywhere that `CLICK_IS_BEFORE_VERSION_8X` is referenced).

Lastly, on the topic of deprecation warnings, I removed `distutiils.version.LooseVersion` and swapped with `packaging.version.parse` since `distutiils` is deprecated and is slated to be removed in Python 3.12, via PEP-632 https://peps.python.org/pep-0632/ And I don't see any good reason for the next version release to not work with Python 3.12, even if only temporarily.