### PR TITLE
fix issue where ctx.exit() did not emit the proper status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This PR closes a number of issues:
 - [#90](https://github.com/ewels/rich-click/issues/90): `click.ClickException` should output to `stderr`
 - [#88](https://github.com/ewels/rich-click/issues/88): Rich Click breaks contract of Click's `format_help` and its callers
 - [#18](https://github.com/ewels/rich-click/issues/18): Options inherited from context settings aren't applied
+- [#114](https://github.com/ewels/rich-click/issues/114): `ctx.exit(exit_code)` not showing nonzero exit codes.
 
 In addition:
 

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -28,7 +28,7 @@ from rich_click.rich_help_configuration import RichHelpConfiguration
 # from click here. This way MyPy will recognize the import and not throw any errors. Furthermore, because of
 # the TYPE_CHECKING check, it does not influence the start routine at all.
 if TYPE_CHECKING:
-    from click import argument, Choice, option, Path, version_option  # noqa: F401
+    from click import argument, Choice, option, pass_context, Path, version_option  # noqa: F401
 
     __all__ = [
         "argument",
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
         "rich_config",
         "RichContext",
         "RichHelpConfiguration",
+        "pass_context",
     ]
 
 

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -1,77 +1,11 @@
-import sys
-from typing import ClassVar, Optional, Type
-
 import click
 
-from rich_click.rich_click import rich_abort_error, rich_format_error, rich_format_help
-from rich_click.rich_context import RichContext
-from rich_click.rich_help_formatter import RichHelpFormatter
+from rich_click.rich_mixin import RichMixin
 
 
-class RichCommand(click.Command):
+class RichCommand(RichMixin, click.Command):
     """Richly formatted click Command.
 
     Inherits click.Command and overrides help and error methods
     to print richly formatted output.
     """
-
-    standalone_mode = False
-    context_class: ClassVar[Type[RichContext]] = RichContext
-
-    def __init__(self, *args, **kwargs):
-        """Create Rich Command.
-
-        Accepts same arguments as Click Command.
-
-        Docs reference: https://click.palletsprojects.com/
-        """
-        super().__init__(*args, **kwargs)
-        self._formatter: Optional[RichHelpFormatter] = None  # type: ignore[annotation-unchecked]
-
-    @property
-    def console(self):
-        """Rich Console.
-
-        This is a separate instance from the help formatter that allows full control of the
-        console configuration.
-
-        See `rich_config` decorator for how to apply the settings.
-        """
-        return self.context_settings.get("rich_console")
-
-    @property
-    def help_config(self):
-        """Rich Help Configuration."""
-        return self.context_settings.get("rich_help_config")
-
-    @property
-    def formatter(self):
-        """Rich Help Formatter.
-
-        This is separate instance from the formatter used to display help,
-        but is created from the same `RichHelpConfiguration`. Currently only used
-        for error reporting.
-        """
-        return self._formatter
-
-    def main(self, *args, standalone_mode: bool = True, **kwargs):
-        formatter = self._formatter = RichHelpFormatter(config=self.help_config)
-        try:
-            rv = super().main(*args, standalone_mode=False, **kwargs)
-            if not standalone_mode:
-                return rv
-        except click.ClickException as e:
-            rich_format_error(e, formatter)
-            if not standalone_mode:
-                raise
-            sys.stderr.write(formatter.getvalue())
-            sys.exit(e.exit_code)
-        except click.exceptions.Abort:
-            rich_abort_error(formatter)
-            if not standalone_mode:
-                raise
-            sys.stderr.write(formatter.getvalue())
-            sys.exit(1)
-
-    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter):
-        rich_format_help(self, ctx, formatter)

--- a/src/rich_click/rich_group.py
+++ b/src/rich_click/rich_group.py
@@ -1,82 +1,20 @@
-import sys
-from typing import Any, Callable, Optional, overload, Type, Union
+from typing import Any, Callable, overload, Type, Union
 
 import click
 
-from rich_click.rich_click import rich_abort_error, rich_format_error, rich_format_help
 from rich_click.rich_command import RichCommand
-from rich_click.rich_context import RichContext
-from rich_click.rich_help_formatter import RichHelpFormatter
+from rich_click.rich_mixin import RichMixin
 
 
-class RichGroup(click.Group):
+class RichGroup(RichMixin, click.Group):
     """Richly formatted click Group.
 
     Inherits click.Group and overrides help and error methods
     to print richly formatted output.
     """
 
-    context_class: Type[RichContext] = RichContext
     command_class: Type[RichCommand] = RichCommand
     group_class = type
-
-    def __init__(self, *args, **kwargs):
-        """Create Rich Group.
-
-        Accepts same arguments as Click Command
-
-        Docs reference: https://click.palletsprojects.com/
-        """
-        super().__init__(*args, **kwargs)
-        self._formatter: Optional[RichHelpFormatter] = None  # type: ignore[annotation-unchecked]
-
-    @property
-    def console(self):
-        """Rich Console.
-
-        This is a separate instance from the help formatter that allows full control of the
-        console configuration.
-
-        See `rich_config` decorator for how to apply the settings.
-        """
-        return self.context_settings.get("rich_console")
-
-    @property
-    def help_config(self):
-        """Rich Help Configuration."""
-        return self.context_settings.get("rich_help_config")
-
-    @property
-    def formatter(self):
-        """Rich Help Formatter.
-
-        This is separate instance from the formatter used to display help,
-        but is created from the same `RichHelpConfiguration`. Currently only used
-        for error reporting.
-        """
-        return self._formatter
-
-    def main(self, *args, standalone_mode: bool = True, **kwargs):
-        formatter = self._formatter = RichHelpFormatter(config=self.help_config)
-        try:
-            rv = super().main(*args, standalone_mode=False, **kwargs)
-            if not standalone_mode:
-                return rv
-        except click.ClickException as e:
-            rich_format_error(e, formatter)
-            if not standalone_mode:
-                raise
-            sys.stderr.write(formatter.getvalue())
-            sys.exit(e.exit_code)
-        except click.exceptions.Abort:
-            rich_abort_error(formatter)
-            if not standalone_mode:
-                raise
-            sys.stderr.write(formatter.getvalue())
-            sys.exit(1)
-
-    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter):
-        rich_format_help(self, ctx, formatter)
 
     @overload
     def command(self, __func: Callable[..., Any]) -> click.Command:

--- a/src/rich_click/rich_mixin.py
+++ b/src/rich_click/rich_mixin.py
@@ -1,0 +1,119 @@
+import errno
+import os
+import sys
+from functools import wraps
+from typing import Any, cast, ClassVar, Optional, Sequence, TextIO, Type
+
+import click
+from click.utils import _detect_program_name, _expand_args, PacifyFlushWrapper
+
+from rich_click.rich_click import rich_abort_error, rich_format_error, rich_format_help
+from rich_click.rich_context import RichContext
+from rich_click.rich_help_formatter import RichHelpFormatter
+
+
+class RichMixin(click.BaseCommand):
+    """Rich formatting mixin for click objects."""
+
+    context_class: ClassVar[Type[RichContext]] = RichContext
+    _formatter: Optional[RichHelpFormatter] = None
+
+    @property
+    def console(self):
+        """Rich Console.
+
+        This is a separate instance from the help formatter that allows full control of the
+        console configuration.
+
+        See `rich_config` decorator for how to apply the settings.
+        """
+        return self.context_settings.get("rich_console")
+
+    @property
+    def help_config(self):
+        """Rich Help Configuration."""
+        return self.context_settings.get("rich_help_config")
+
+    @property
+    def formatter(self) -> RichHelpFormatter:
+        """Rich Help Formatter.
+
+        This is separate instance from the formatter used to display help,
+        but is created from the same `RichHelpConfiguration`. Currently only used
+        for error reporting.
+        """
+        if self._formatter is None:
+            self._formatter = RichHelpFormatter(config=self.help_config)
+        return self._formatter
+
+    @wraps(click.BaseCommand.main)
+    def main(
+        self,
+        args: Optional[Sequence[str]] = None,
+        prog_name: Optional[str] = None,
+        complete_var: Optional[str] = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        # It's not feasible to use super().main() in this context and retain exact parity in behavior.
+        # The reason why is explained in a comment in click's source code in the "except Exit as e" block.
+
+        if args is None:
+            args = sys.argv[1:]
+
+            if os.name == "nt" and windows_expand_args:
+                args = _expand_args(args)
+        else:
+            args = list(args)
+
+        if prog_name is None:
+            prog_name = _detect_program_name()
+
+        # Process shell completion requests and exit early.
+        self._main_shell_completion(extra, prog_name, complete_var)
+
+        try:
+            try:
+                with self.make_context(prog_name, args, **extra) as ctx:
+                    rv = self.invoke(ctx)
+                    if not standalone_mode:
+                        return rv
+                    # it's not safe to `ctx.exit(rv)` here!
+                    # note that `rv` may actually contain data like "1" which
+                    # has obvious effects
+                    # more subtle case: `rv=[None, None]` can come out of
+                    # chained commands which all returned `None` -- so it's not
+                    # even always obvious that `rv` indicates success/failure
+                    # by its truthiness/falsiness
+                    ctx.exit()
+            except (EOFError, KeyboardInterrupt):
+                click.echo(file=sys.stderr)
+                raise click.exceptions.Abort() from None
+            except click.exceptions.ClickException as e:
+                rich_format_error(e, self.formatter)
+                if not standalone_mode:
+                    raise
+                sys.stderr.write(self.formatter.getvalue())
+                sys.exit(e.exit_code)
+            except OSError as e:
+                if e.errno == errno.EPIPE:
+                    sys.stdout = cast(TextIO, PacifyFlushWrapper(sys.stdout))
+                    sys.stderr = cast(TextIO, PacifyFlushWrapper(sys.stderr))
+                    sys.exit(1)
+                else:
+                    raise
+        except click.exceptions.Exit as e:
+            if standalone_mode:
+                sys.exit(e.exit_code)
+            else:
+                return e.exit_code
+        except click.exceptions.Abort:
+            rich_abort_error(self.formatter)
+            if not standalone_mode:
+                raise
+            sys.stderr.write(self.formatter.getvalue())
+            sys.exit(1)
+
+    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter):
+        rich_format_help(self, ctx, formatter)

--- a/tests/test_exit_code.py
+++ b/tests/test_exit_code.py
@@ -1,0 +1,122 @@
+import sys
+
+from click.testing import CliRunner
+
+from rich_click import command, group, pass_context, RichContext
+
+# Don't use the 'invoke' fixture because we want control over the standalone_mode kwarg.
+
+
+def test_command_exit_code_with_context():
+    for expected_exit_code in range(10):
+
+        @command("cli")
+        @pass_context
+        def cli(ctx: RichContext):
+            ctx.exit(expected_exit_code)
+
+        runner = CliRunner()
+        res = runner.invoke(cli, [])
+        assert res.exit_code == expected_exit_code
+
+
+def test_group_exit_code_with_context():
+    for expected_exit_code in range(10):
+
+        @group("cli")
+        @pass_context
+        def cli(ctx: RichContext):
+            ctx.exit(expected_exit_code)
+
+        @cli.command("subcommand")
+        @pass_context
+        def subcommand(ctx: RichContext):
+            ctx.exit(999)
+
+        runner = CliRunner()
+        res = runner.invoke(cli, ["subcommand"])
+        assert res.exit_code == expected_exit_code
+
+
+def test_command_exit_code_with_sys_exit():
+    for expected_exit_code in range(10):
+
+        @command("cli")
+        def cli():
+            sys.exit(expected_exit_code)
+
+        runner = CliRunner()
+        res = runner.invoke(cli, [])
+        assert res.exit_code == expected_exit_code
+
+
+def test_group_exit_code_with_sys_exit():
+    for expected_exit_code in range(10):
+
+        @group("cli")
+        def cli():
+            sys.exit(expected_exit_code)
+
+        @cli.command("subcommand")
+        def subcommand():
+            sys.exit(999)
+
+        runner = CliRunner()
+        res = runner.invoke(cli, ["subcommand"])
+        assert res.exit_code == expected_exit_code
+
+
+def test_command_return_value_does_not_raise_exit_code():
+    @command("cli")
+    def cli():
+        return 5
+
+    runner = CliRunner()
+    res = runner.invoke(cli, [])
+    assert res.exit_code == 0
+
+
+def test_group_return_value_does_not_raise_exit_code():
+    @group("cli")
+    def cli():
+        return 5
+
+    @cli.command("subcommand")
+    def subcommand():
+        return 10
+
+    runner = CliRunner()
+    res = runner.invoke(cli, [])
+    assert res.exit_code == 0
+
+
+def test_command_return_value_is_exit_code_when_not_standalone():
+    for expected_exit_code in range(10):
+
+        @command("cli")
+        @pass_context
+        def cli(ctx: RichContext):
+            ctx.exit(expected_exit_code)
+
+        runner = CliRunner()
+        res = runner.invoke(cli, [], standalone_mode=False)
+        assert res.return_value == expected_exit_code
+
+
+def test_group_return_value_is_exit_code_when_not_standalone():
+    for expected_exit_code in range(10):
+
+        @group("cli")
+        @pass_context
+        def cli(ctx: RichContext):
+            ctx.exit(expected_exit_code)
+
+        @cli.command("subcommand")
+        @pass_context
+        def subcommand(ctx: RichContext):
+            # I should not run
+            ctx.exit(0)
+
+        runner = CliRunner()
+        res = runner.invoke(cli, ["subcommand"], standalone_mode=False)
+        assert res.return_value == expected_exit_code


### PR DESCRIPTION
- Resolve #114
- Added tests that replicate all of Click's behaviors in regards to exit codes.
- Created `RichMixin` class to reduce repetition of code.

I could not figure out a way to have full parity with click's functionality without re-implementing all of `click.BaseCommand.main()`. The reasons are explained in the comments for `click.BaseCommand.main()`, but tldr: . The downside to this is that it is not necessarily guaranteed to be forward compatible. But click is a relatively stable library with a slow and mature release cycle, so this is not a high cost.

I'd lik @ewels to review my use of a mixin. I am not sure if this was something you were avoiding for any particular reason. If you'd like I can avoid using the mixin approach, just let me know. I found it to be easier to switch to this so we don't need to reimplement all of that `main()` logic in multiple places.