### PR TITLE
[Draft] Fix typing and other bugs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,4 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+      - name: Install dependencies
+        run: pip install '.[dev]'
       - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,9 +47,9 @@ repos:
         name: mypy - Static type checking
         description: Mypy helps ensure that we use our functions and variables correctly by checking the types.
         entry: mypy
-        language: python
+        language: system
         types: [python]
         exclude: ^examples/|^tests/fixtures/
         require_serial: true
-        additional_dependencies:
-          - mypy
+#        additional_dependencies:
+#          - mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,5 @@ repos:
         entry: mypy
         language: system
         types: [python]
-        exclude: ^examples/|^tests/fixtures/
+        exclude: ^examples/
         require_serial: true
-#        additional_dependencies:
-#          - mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@ This release comes after merging a huge pull-request from [@BrutalSimplicity](ht
 This PR closes a number of issues:
 
 - [#25](https://github.com/ewels/rich-click/issues/25): Add tests!
-- [#38](https://github.com/ewels/rich-click/issues/38): Support `click.MultiCommand`
 - [#90](https://github.com/ewels/rich-click/issues/90): `click.ClickException` should output to `stderr`
 - [#88](https://github.com/ewels/rich-click/issues/88): Rich Click breaks contract of Click's `format_help` and its callers
 - [#18](https://github.com/ewels/rich-click/issues/18): Options inherited from context settings aren't applied
-- [#114](https://github.com/ewels/rich-click/issues/114): `ctx.exit(exit_code)` not showing nonzero exit codes.
+
+In addition, we merged another large pull-request that adds **full static type-checking support** (see issue [#85](https://github.com/ewels/rich-click/issues/85)), and fixes many bugs - see PR [#126](https://github.com/ewels/rich-click/pull/126).
 
 In addition:
 
@@ -32,6 +32,8 @@ In addition:
 - Add new style option `WIDTH` (in addition to `MAX_WIDTH`), thanks to [@ealap](httpsd://github.com/ealap) [[#110](https://github.com/ewels/rich-click/pull/110)]
 - Updated styling for `Usage:` line to avoid off-target effects [[#108](https://github.com/ewels/rich-click/issues/108)]
 - Click 7.x support has been deprecated. [[#117](https://github.com/ewels/rich-click/pull/117)]
+- Fixed error where `ctx.exit(exit_code)` would not show nonzero exit codes.[[#114](https://github.com/ewels/rich-click/issues/114)]
+- Support `click.MultiCommand`. [[#38](https://github.com/ewels/rich-click/issues/38)]:
 
 ## Version 1.6.1 (2023-01-19)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,8 @@ profile = "black"
 
 [tool.mypy]
 python_version = "3.8"
-ignore_missing_imports = "True"
 scripts_are_modules = "True"
 # strict = "True"
-# follow_imports = "skip"
 
 [tool.pyright]
 include = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ profile = "black"
 [tool.mypy]
 python_version = "3.8"
 scripts_are_modules = "True"
-# strict = "True"
+strict = "True"
 
 [tool.pyright]
 include = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,11 @@ sections = [
 profile = "black"
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.8"
 ignore_missing_imports = "True"
 scripts_are_modules = "True"
+# strict = "True"
+# follow_imports = "skip"
 
 [tool.pyright]
 include = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 setup(
     install_requires=["click>=7", "rich>=10.7.0", "importlib-metadata; python_version < '3.8'", "typing_extensions"],
     extras_require={
-        "dev": ["pre-commit", "pytest", "flake8", "flake8-docstrings", "pytest-cov", "packaging"],
+        "dev": ["pre-commit", "pytest", "flake8", "flake8-docstrings", "pytest-cov", "packaging", "types-setuptools"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,15 @@ from setuptools import setup
 setup(
     install_requires=["click>=7", "rich>=10.7.0", "importlib-metadata; python_version < '3.8'", "typing_extensions"],
     extras_require={
-        "dev": ["pre-commit", "pytest", "flake8", "flake8-docstrings", "pytest-cov", "packaging", "types-setuptools"],
+        "dev": [
+            "mypy",
+            "pre-commit",
+            "pytest",
+            "flake8",
+            "flake8-docstrings",
+            "pytest-cov",
+            "packaging",
+            "types-setuptools",
+        ],
     },
 )

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -12,7 +12,6 @@ __version__ = "1.7.0dev"
 # We need to manually import these instead of `from click import *` to force mypy to recognize a few type annotation overrides for the rich_click decorators.
 from click.core import Argument as Argument
 from click.core import Command as Command
-from click.core import CommandCollection as CommandCollection
 from click.core import Context as Context
 from click.core import Group as Group
 from click.core import Option as Option
@@ -83,8 +82,6 @@ from rich_click.rich_help_configuration import RichHelpConfiguration as RichHelp
 
 
 def __getattr__(name: str) -> object:
-    import click
-
     from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_9X
 
     if name == "RichMultiCommand" and CLICK_IS_BEFORE_VERSION_9X:
@@ -100,4 +97,6 @@ def __getattr__(name: str) -> object:
         return RichMultiCommand
 
     else:
+        import click
+
         return getattr(click, name)

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -8,13 +8,73 @@ customisation required.
 
 __version__ = "1.7.0dev"
 
-from click import *
+# Import the entire click API here.
+# We need to manually import these instead of `from click import *` to force mypy to recognize a few type annotation overrides for the rich_click decorators.
+from click.core import Argument as Argument
+from click.core import Command as Command
+from click.core import CommandCollection as CommandCollection
+from click.core import Context as Context
+from click.core import Group as Group
+from click.core import Option as Option
+from click.core import Parameter as Parameter
+from click.decorators import argument as argument
+from click.decorators import confirmation_option as confirmation_option
+from click.decorators import help_option as help_option
+from click.decorators import make_pass_decorator as make_pass_decorator
+from click.decorators import option as option
+from click.decorators import pass_obj as pass_obj
+from click.decorators import password_option as password_option
+from click.decorators import version_option as version_option
+from click.exceptions import Abort as Abort
+from click.exceptions import BadArgumentUsage as BadArgumentUsage
+from click.exceptions import BadOptionUsage as BadOptionUsage
+from click.exceptions import BadParameter as BadParameter
+from click.exceptions import ClickException as ClickException
+from click.exceptions import FileError as FileError
+from click.exceptions import MissingParameter as MissingParameter
+from click.exceptions import NoSuchOption as NoSuchOption
+from click.exceptions import UsageError as UsageError
+from click.formatting import HelpFormatter as HelpFormatter
+from click.formatting import wrap_text as wrap_text
+from click.globals import get_current_context as get_current_context
+from click.termui import clear as clear
+from click.termui import confirm as confirm
+from click.termui import echo_via_pager as echo_via_pager
+from click.termui import edit as edit
+from click.termui import getchar as getchar
+from click.termui import launch as launch
+from click.termui import pause as pause
+from click.termui import progressbar as progressbar
+from click.termui import prompt as prompt
+from click.termui import secho as secho
+from click.termui import style as style
+from click.termui import unstyle as unstyle
+from click.types import BOOL as BOOL
+from click.types import Choice as Choice
+from click.types import DateTime as DateTime
+from click.types import File as File
+from click.types import FLOAT as FLOAT
+from click.types import FloatRange as FloatRange
+from click.types import INT as INT
+from click.types import IntRange as IntRange
+from click.types import ParamType as ParamType
+from click.types import Path as Path
+from click.types import STRING as STRING
+from click.types import Tuple as Tuple
+from click.types import UNPROCESSED as UNPROCESSED
+from click.types import UUID as UUID
+from click.utils import echo as echo
+from click.utils import format_filename as format_filename
+from click.utils import get_app_dir as get_app_dir
+from click.utils import get_binary_stream as get_binary_stream
+from click.utils import get_text_stream as get_text_stream
+from click.utils import open_file as open_file
 
 from . import rich_click as rich_click
 
-from rich_click.decorators import command as command  # type: ignore[no-redef]
-from rich_click.decorators import group as group  # type: ignore[no-redef]
-from rich_click.decorators import pass_context as pass_context  # type: ignore[no-redef,assignment]
+from rich_click.decorators import command as command
+from rich_click.decorators import group as group
+from rich_click.decorators import pass_context as pass_context
 from rich_click.decorators import rich_config as rich_config
 from rich_click.rich_command import RichCommand as RichCommand
 from rich_click.rich_command import RichGroup as RichGroup
@@ -41,8 +101,5 @@ def __getattr__(name: str) -> object:
         return RichMultiCommand
 
     # Support for potentially deprecated objects in newer versions of click:
-    elif name in {"BaseCommand", "OptionParser", "MultiCommand"}:
-        return getattr(click, name)
-
     else:
-        raise AttributeError(name)
+        return getattr(click, name)

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -12,6 +12,7 @@ __version__ = "1.7.0dev"
 # We need to manually import these instead of `from click import *` to force mypy to recognize a few type annotation overrides for the rich_click decorators.
 from click.core import Argument as Argument
 from click.core import Command as Command
+from click.core import CommandCollection as CommandCollection
 from click.core import Context as Context
 from click.core import Group as Group
 from click.core import Option as Option
@@ -76,6 +77,7 @@ from rich_click.decorators import group as group
 from rich_click.decorators import pass_context as pass_context
 from rich_click.decorators import rich_config as rich_config
 from rich_click.rich_command import RichCommand as RichCommand
+from rich_click.rich_command import RichCommandCollection as RichCommandCollection
 from rich_click.rich_command import RichGroup as RichGroup
 from rich_click.rich_context import RichContext as RichContext
 from rich_click.rich_help_configuration import RichHelpConfiguration as RichHelpConfiguration

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -12,12 +12,37 @@ from click import *
 
 from . import rich_click as rich_click
 
-from rich_click.decorators import command as command
-from rich_click.decorators import group as group
+from rich_click.decorators import command as command  # type: ignore[no-redef]
+from rich_click.decorators import group as group  # type: ignore[no-redef]
+from rich_click.decorators import pass_context as pass_context  # type: ignore[no-redef,assignment]
 from rich_click.decorators import rich_config as rich_config
-from rich_click.rich_command import RichBaseCommand as RichBaseCommand
 from rich_click.rich_command import RichCommand as RichCommand
 from rich_click.rich_command import RichGroup as RichGroup
 from rich_click.rich_command import RichMultiCommand as RichMultiCommand
 from rich_click.rich_context import RichContext as RichContext
 from rich_click.rich_help_configuration import RichHelpConfiguration as RichHelpConfiguration
+
+
+def __getattr__(name: str) -> object:
+    import click
+
+    from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_9X
+
+    if name == "RichMultiCommand" and CLICK_IS_BEFORE_VERSION_9X:
+        import warnings
+
+        warnings.warn(
+            "'RichMultiCommand' is deprecated and will be removed in Click 9.0. Use" " 'RichGroup' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from rich_click.rich_command import RichMultiCommand
+
+        return RichMultiCommand
+
+    # Support for potentially deprecated objects in newer versions of click:
+    elif name in {"BaseCommand", "OptionParser", "MultiCommand"}:
+        return getattr(click, name)
+
+    else:
+        raise AttributeError(name)

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 """
 rich-click is a minimal Python module to combine the efforts of the excellent packages 'rich' and 'click'.
 
@@ -7,141 +8,16 @@ customisation required.
 
 __version__ = "1.7.0dev"
 
-from typing import Any, Callable, cast, Optional, overload, TYPE_CHECKING, Union
+from click import *
 
-from click import *  # noqa: F401, F403
-from click import Command
-from click import command as click_command
-from click import Group
-from click import group as click_group
-from rich.console import Console
+from . import rich_click as rich_click
 
-from . import rich_click  # noqa: F401
-
-from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X as _CLICK_IS_BEFORE_VERSION_8X
-from rich_click.rich_command import RichBaseCommand, RichCommand, RichGroup, RichMultiCommand  # noqa: F401
-from rich_click.rich_context import RichContext
-from rich_click.rich_help_configuration import RichHelpConfiguration
-
-# MyPy does not like star imports. Therefore when we are type checking, we import each individual module
-# from click here. This way MyPy will recognize the import and not throw any errors. Furthermore, because of
-# the TYPE_CHECKING check, it does not influence the start routine at all.
-if TYPE_CHECKING:
-    from click import argument, Choice, option, pass_context, Path, version_option  # noqa: F401
-
-    __all__ = [
-        "argument",
-        "Choice",
-        "option",
-        "Path",
-        "version_option",
-        "group",
-        "command",
-        "rich_config",
-        "RichContext",
-        "RichHelpConfiguration",
-        "pass_context",
-    ]
-
-
-def group(name=None, cls=RichGroup, **attrs) -> Callable[..., RichGroup]:
-    """
-    Group decorator function.
-
-    Defines the group() function so that it uses the RichGroup class by default.
-    """
-
-    def wrapper(fn):
-        if hasattr(fn, "__rich_context_settings__"):
-            rich_context_settings = getattr(fn, "__rich_context_settings__", {})
-            console = rich_context_settings.get("rich_console", None)
-            help_config = rich_context_settings.get("help_config", None)
-            context_settings = attrs.get("context_settings", {})
-            context_settings.update(rich_console=console, rich_help_config=help_config)
-            attrs.update(context_settings=context_settings)
-            del fn.__rich_context_settings__
-        if callable(name) and cls:
-            group = click_group(cls=cls, **attrs)(name)
-        else:
-            group = click_group(name, cls=cls, **attrs)
-        cmd = cast(RichGroup, group(fn))
-        return cmd
-
-    return wrapper
-
-
-def command(name=None, cls=RichCommand, **attrs) -> Callable[..., RichCommand]:
-    """
-    Command decorator function.
-
-    Defines the command() function so that it uses the RichCommand class by default.
-    """
-
-    def wrapper(fn):
-        if hasattr(fn, "__rich_context_settings__"):
-            rich_context_settings = getattr(fn, "__rich_context_settings__", {})
-            console = rich_context_settings.get("rich_console", None)
-            help_config = rich_context_settings.get("help_config", None)
-            context_settings = attrs.get("context_settings", {})
-            context_settings.update(rich_console=console, rich_help_config=help_config)
-            attrs.update(context_settings=context_settings)
-            del fn.__rich_context_settings__
-        if callable(name) and cls:
-            command = click_command(cls=cls, **attrs)(name)
-        else:
-            command = click_command(name, cls=cls, **attrs)
-        cmd = cast(RichCommand, command(fn))
-        return cmd
-
-    return wrapper
-
-
-class NotSupportedError(Exception):
-    """Not Supported Error."""
-
-    pass
-
-
-def rich_config(console: Optional[Console] = None, help_config: Optional[RichHelpConfiguration] = None):
-    """Use decorator to configure Rich Click settings.
-
-    Args:
-        console: A Rich Console that will be accessible from the `RichContext`, `RichCommand`, and `RichGroup` instances
-            Defaults to None.
-        help_config: Rich help configuration that is used internally to format help messages and exceptions
-            Defaults to None.
-    """
-    if _CLICK_IS_BEFORE_VERSION_8X:
-
-        def decorator_with_warning(obj):
-            import warnings
-
-            warnings.warn(
-                "`rich_config()` does not work with versions of click prior to version 8.0.0."
-                " Please update to a newer version of click to use this functionality.",
-                RuntimeWarning,
-            )
-            return obj
-
-        return decorator_with_warning
-
-    @overload
-    def decorator(obj: Union[RichCommand, RichGroup]) -> Union[RichCommand, RichGroup]:
-        ...
-
-    @overload
-    def decorator(obj: Callable[..., Any]) -> Callable[..., Any]:
-        ...
-
-    def decorator(obj):
-        if isinstance(obj, (RichCommand, RichGroup)):
-            obj.context_settings.update({"rich_console": console, "rich_help_config": help_config})
-        elif callable(obj) and not isinstance(obj, (Command, Group)):
-            setattr(obj, "__rich_context_settings__", {"rich_console": console, "rich_help_config": help_config})
-        else:
-            raise NotSupportedError("`rich_config` requires a `RichCommand` or `RichGroup`. Try using the cls keyword")
-
-        decorator.__doc__ = obj.__doc__
-        return obj
-
-    return decorator
+from rich_click.decorators import command as command
+from rich_click.decorators import group as group
+from rich_click.decorators import rich_config as rich_config
+from rich_click.rich_command import RichBaseCommand as RichBaseCommand
+from rich_click.rich_command import RichCommand as RichCommand
+from rich_click.rich_command import RichGroup as RichGroup
+from rich_click.rich_command import RichMultiCommand as RichMultiCommand
+from rich_click.rich_context import RichContext as RichContext
+from rich_click.rich_help_configuration import RichHelpConfiguration as RichHelpConfiguration

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -78,7 +78,6 @@ from rich_click.decorators import pass_context as pass_context
 from rich_click.decorators import rich_config as rich_config
 from rich_click.rich_command import RichCommand as RichCommand
 from rich_click.rich_command import RichGroup as RichGroup
-from rich_click.rich_command import RichMultiCommand as RichMultiCommand
 from rich_click.rich_context import RichContext as RichContext
 from rich_click.rich_help_configuration import RichHelpConfiguration as RichHelpConfiguration
 
@@ -92,7 +91,7 @@ def __getattr__(name: str) -> object:
         import warnings
 
         warnings.warn(
-            "'RichMultiCommand' is deprecated and will be removed in Click 9.0. Use" " 'RichGroup' instead.",
+            "'RichMultiCommand' is deprecated and will be removed in Click 9.0. Use 'RichGroup' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -100,6 +99,5 @@ def __getattr__(name: str) -> object:
 
         return RichMultiCommand
 
-    # Support for potentially deprecated objects in newer versions of click:
     else:
         return getattr(click, name)

--- a/src/rich_click/_compat_click.py
+++ b/src/rich_click/_compat_click.py
@@ -1,8 +1,8 @@
 try:
-    from importlib import metadata  # type: ignore
+    from importlib import metadata  # type: ignore[import,unused-ignore]
 except ImportError:
     # Python < 3.8
-    import importlib_metadata as metadata  # type: ignore
+    import importlib_metadata as metadata  # type: ignore[no-redef,import]
 
 
 click_version = metadata.version("click")

--- a/src/rich_click/_compat_click.py
+++ b/src/rich_click/_compat_click.py
@@ -11,6 +11,7 @@ _minor = int(click_version.split(".")[1])
 
 
 CLICK_IS_BEFORE_VERSION_8X = _major < 8
+CLICK_IS_BEFORE_VERSION_9X = _major < 9
 CLICK_IS_VERSION_80 = _major == 8 and _minor == 0
 
 

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -19,7 +19,7 @@ from rich.text import Text
 
 from rich_click import command as rich_command
 from rich_click import group as rich_group
-from rich_click import RichCommand, RichGroup, RichMultiCommand
+from rich_click import RichCommand, RichCommandCollection, RichGroup, RichMultiCommand
 from rich_click.rich_click import (
     ALIGN_ERRORS_PANEL,
     ERRORS_PANEL_TITLE,
@@ -68,6 +68,7 @@ def patch() -> None:
     click.command = rich_command
     click.Group = RichGroup  # type: ignore[misc]
     click.Command = RichCommand  # type: ignore[misc]
+    click.CommandCollection = RichCommandCollection  # type: ignore[misc]
     if "MultiCommand" in dir(click):
         click.MultiCommand = RichMultiCommand  # type: ignore[assignment,misc]
 

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -68,7 +68,8 @@ def patch() -> None:
     click.command = rich_command
     click.Group = RichGroup  # type: ignore[misc]
     click.Command = RichCommand  # type: ignore[misc]
-    click.MultiCommand = RichMultiCommand  # type: ignore[misc]
+    if "MultiCommand" in dir(click):
+        click.MultiCommand = RichMultiCommand  # type: ignore[assignment,misc]
 
 
 def main(args: Optional[List[str]] = None) -> Any:

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -6,10 +6,10 @@ from textwrap import dedent
 from typing import Any, List, Optional
 
 try:
-    from importlib.metadata import entry_points
+    from importlib.metadata import entry_points  # type: ignore[import,unused-ignore]
 except ImportError:
     # Support Python <3.8
-    from importlib_metadata import entry_points  # type: ignore[no-redef]
+    from importlib_metadata import entry_points  # type: ignore[import,no-redef]
 
 import click
 from rich.console import Console

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -19,7 +19,7 @@ from rich.text import Text
 
 from rich_click import command as rich_command
 from rich_click import group as rich_group
-from rich_click import RichBaseCommand, RichCommand, RichGroup, RichMultiCommand
+from rich_click import RichCommand, RichGroup, RichMultiCommand
 from rich_click.rich_click import (
     ALIGN_ERRORS_PANEL,
     ERRORS_PANEL_TITLE,
@@ -68,7 +68,6 @@ def patch() -> None:
     click.command = rich_command
     click.Group = RichGroup  # type: ignore[misc]
     click.Command = RichCommand  # type: ignore[misc]
-    click.BaseCommand = RichBaseCommand  # type: ignore[misc]
     click.MultiCommand = RichMultiCommand  # type: ignore[misc]
 
 
@@ -99,7 +98,7 @@ def main(args: Optional[List[str]] = None) -> Any:
         sys.exit(0)
     else:
         script_name = args[0]
-    scripts = {script.name: script for script in entry_points().get("console_scripts")}
+    scripts = {script.name: script for script in entry_points().get("console_scripts", [])}
     if script_name in scripts:
         # a valid script was passed
         script = scripts[script_name]

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -9,7 +9,7 @@ try:
     from importlib.metadata import entry_points
 except ImportError:
     # Support Python <3.8
-    from importlib_metadata import entry_points
+    from importlib_metadata import entry_points  # type: ignore[no-redef]
 
 import click
 from rich.console import Console
@@ -66,10 +66,10 @@ def patch() -> None:
     """Patch Click internals to use Rich-Click types."""
     click.group = rich_group
     click.command = rich_command
-    click.Group = RichGroup
-    click.Command = RichCommand
-    click.BaseCommand = RichBaseCommand
-    click.RichMultiCommand = RichMultiCommand
+    click.Group = RichGroup  # type: ignore[misc]
+    click.Command = RichCommand  # type: ignore[misc]
+    click.BaseCommand = RichBaseCommand  # type: ignore[misc]
+    click.MultiCommand = RichMultiCommand  # type: ignore[misc]
 
 
 def main(args: Optional[List[str]] = None) -> Any:

--- a/src/rich_click/decorators.py
+++ b/src/rich_click/decorators.py
@@ -1,0 +1,124 @@
+"""
+rich-click is a minimal Python module to combine the efforts of the excellent packages 'rich' and 'click'.
+
+The intention is to provide attractive help output from click, formatted with rich, with minimal
+customisation required.
+"""
+
+__version__ = "1.7.0dev"
+
+from typing import Any, Callable, cast, Optional, Type, TypeVar
+
+from click import Command
+from click import command as click_command
+from click import Group
+from click import group as click_group
+from rich.console import Console
+
+from . import rich_click  # noqa: F401
+
+from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
+from rich_click.rich_command import RichBaseCommand, RichCommand, RichGroup, RichMultiCommand  # noqa: F401
+from rich_click.rich_help_configuration import RichHelpConfiguration
+
+# MyPy does not like star imports. Therefore when we are type checking, we import each individual module
+# from click here. This way MyPy will recognize the import and not throw any errors. Furthermore, because of
+# the TYPE_CHECKING check, it does not influence the start routine at all.
+
+F = TypeVar("F", bound=Callable[..., Any])
+FC = TypeVar("FC", RichCommand, Callable[..., Any])
+
+
+def group(name: Optional[str] = None, cls: Optional[Type[Group]] = RichGroup, **attrs: Any) -> Callable[[F], Group]:
+    """
+    Group decorator function.
+
+    Defines the group() function so that it uses the RichGroup class by default.
+    """
+
+    def wrapper(fn):
+        if hasattr(fn, "__rich_context_settings__"):
+            rich_context_settings = getattr(fn, "__rich_context_settings__", {})
+            console = rich_context_settings.get("rich_console", None)
+            help_config = rich_context_settings.get("help_config", None)
+            context_settings = attrs.get("context_settings", {})
+            context_settings.update(rich_console=console, rich_help_config=help_config)
+            attrs.update(context_settings=context_settings)
+            del fn.__rich_context_settings__
+        if callable(name) and cls:
+            group = click_group(cls=cls, **attrs)(name)
+        else:
+            group = click_group(name, cls=cls, **attrs)
+        cmd = cast(RichGroup, group(fn))
+        return cmd
+
+    return wrapper
+
+
+def command(name: str = None, cls: Optional[Type[Group]] = RichCommand, **attrs: Any) -> Callable[[F], Group]:
+    """
+    Command decorator function.
+
+    Defines the command() function so that it uses the RichCommand class by default.
+    """
+
+    def wrapper(fn):
+        if hasattr(fn, "__rich_context_settings__"):
+            rich_context_settings = getattr(fn, "__rich_context_settings__", {})
+            console = rich_context_settings.get("rich_console", None)
+            help_config = rich_context_settings.get("help_config", None)
+            context_settings = attrs.get("context_settings", {})
+            context_settings.update(rich_console=console, rich_help_config=help_config)
+            attrs.update(context_settings=context_settings)
+            del fn.__rich_context_settings__
+        if callable(name) and cls:
+            command = click_command(cls=cls, **attrs)(name)
+        else:
+            command = click_command(name, cls=cls, **attrs)
+        cmd = cast(RichCommand, command(fn))
+        return cmd
+
+    return wrapper
+
+
+class NotSupportedError(Exception):
+    """Not Supported Error."""
+
+    pass
+
+
+def rich_config(console: Optional[Console] = None, help_config: Optional[RichHelpConfiguration] = None):
+    """Use decorator to configure Rich Click settings.
+
+    Args:
+        console: A Rich Console that will be accessible from the `RichContext`, `RichCommand`, and `RichGroup` instances
+            Defaults to None.
+        help_config: Rich help configuration that is used internally to format help messages and exceptions
+            Defaults to None.
+    """
+    if CLICK_IS_BEFORE_VERSION_8X:
+
+        def decorator_with_warning(obj):
+            import warnings
+
+            warnings.warn(
+                "`rich_config()` does not work with versions of click prior to version 8.0.0."
+                " Please update to a newer version of click to use this functionality.",
+                RuntimeWarning,
+            )
+            return obj
+
+        return decorator_with_warning
+
+    def decorator(obj: FC) -> FC:
+        if isinstance(obj, (RichCommand, RichGroup)):
+            obj.context_settings.update({"rich_console": console, "rich_help_config": help_config})
+        elif callable(obj) and not isinstance(obj, (Command, Group)):
+            setattr(obj, "__rich_context_settings__", {"rich_console": console, "rich_help_config": help_config})
+        else:
+            raise NotSupportedError("`rich_config` requires a `RichCommand` or `RichGroup`. Try using the cls keyword")
+
+        decorator.__doc__ = obj.__doc__
+        return obj
+
+    return decorator

--- a/src/rich_click/decorators.py
+++ b/src/rich_click/decorators.py
@@ -7,7 +7,7 @@ customisation required.
 
 __version__ = "1.7.0dev"
 
-from typing import Any, Callable, cast, Optional, overload, Type, TYPE_CHECKING, TypeVar, Union
+from typing import Any, Callable, cast, Dict, Optional, overload, Type, TYPE_CHECKING, TypeVar, Union
 
 from click import Command
 from click import command as click_command
@@ -177,10 +177,16 @@ def rich_config(
         return decorator_with_warning
 
     def decorator(obj: FC) -> FC:
+        extra: Dict[str, Any] = {}
+        if console is not None:
+            extra["rich_console"] = console
+        if help_config is not None:
+            extra["rich_help_config"] = help_config
+
         if isinstance(obj, (RichCommand, RichGroup)):
-            obj.context_settings.update({"rich_console": console, "rich_help_config": help_config})
+            obj.context_settings.update(extra)
         elif callable(obj) and not isinstance(obj, (Command, Group)):
-            setattr(obj, "__rich_context_settings__", {"rich_console": console, "rich_help_config": help_config})
+            setattr(obj, "__rich_context_settings__", extra)
         else:
             raise NotSupportedError("`rich_config` requires a `RichCommand` or `RichGroup`. Try using the cls keyword")
         return obj

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 from os import getenv
-from typing import Dict, Iterable, List, Optional, TYPE_CHECKING, Union
+from typing import Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import click
 import rich.columns
@@ -31,90 +31,94 @@ except ImportError:
     from rich.console import render_group as group  # type: ignore[attr-defined,no-redef]
 
 # Default styles
-STYLE_OPTION = "bold cyan"
-STYLE_ARGUMENT = "bold cyan"
-STYLE_COMMAND = "bold cyan"
-STYLE_SWITCH = "bold green"
-STYLE_METAVAR = "bold yellow"
-STYLE_METAVAR_APPEND = "dim yellow"
-STYLE_METAVAR_SEPARATOR = "dim"
-STYLE_HEADER_TEXT = ""
-STYLE_FOOTER_TEXT = ""
-STYLE_USAGE = "yellow"
-STYLE_USAGE_COMMAND = "bold"
-STYLE_DEPRECATED = "red"
-STYLE_HELPTEXT_FIRST_LINE = ""
-STYLE_HELPTEXT = "dim"
-STYLE_OPTION_HELP = ""
-STYLE_OPTION_DEFAULT = "dim"
-STYLE_OPTION_ENVVAR = "dim yellow"
-STYLE_REQUIRED_SHORT = "red"
-STYLE_REQUIRED_LONG = "dim red"
-STYLE_OPTIONS_PANEL_BORDER = "dim"
-ALIGN_OPTIONS_PANEL: Literal["left", "center", "right"] = "left"
-STYLE_OPTIONS_TABLE_SHOW_LINES = False
-STYLE_OPTIONS_TABLE_LEADING = 0
-STYLE_OPTIONS_TABLE_PAD_EDGE = False
-STYLE_OPTIONS_TABLE_PADDING = (0, 1)
-STYLE_OPTIONS_TABLE_BOX = ""
-STYLE_OPTIONS_TABLE_ROW_STYLES = None
-STYLE_OPTIONS_TABLE_BORDER_STYLE = None
-STYLE_COMMANDS_PANEL_BORDER = "dim"
-ALIGN_COMMANDS_PANEL: Literal["left", "center", "right"] = "left"
-STYLE_COMMANDS_TABLE_SHOW_LINES = False
-STYLE_COMMANDS_TABLE_LEADING = 0
-STYLE_COMMANDS_TABLE_PAD_EDGE = False
-STYLE_COMMANDS_TABLE_PADDING = (0, 1)
-STYLE_COMMANDS_TABLE_BOX = ""
-STYLE_COMMANDS_TABLE_ROW_STYLES = None
-STYLE_COMMANDS_TABLE_BORDER_STYLE = None
-STYLE_COMMANDS_TABLE_COLUMN_WIDTH_RATIO = (None, None)
-STYLE_ERRORS_PANEL_BORDER = "red"
-ALIGN_ERRORS_PANEL: Literal["left", "center", "right"] = "left"
-STYLE_ERRORS_SUGGESTION = "dim"
-STYLE_ABORTED = "red"
-WIDTH = int(getenv("TERMINAL_WIDTH")) if getenv("TERMINAL_WIDTH") else None  # type: ignore
-MAX_WIDTH = int(getenv("TERMINAL_WIDTH")) if getenv("TERMINAL_WIDTH") else WIDTH  # type: ignore
+STYLE_OPTION: rich.style.StyleType = "bold cyan"
+STYLE_ARGUMENT: rich.style.StyleType = "bold cyan"
+STYLE_COMMAND: rich.style.StyleType = "bold cyan"
+STYLE_SWITCH: rich.style.StyleType = "bold green"
+STYLE_METAVAR: rich.style.StyleType = "bold yellow"
+STYLE_METAVAR_APPEND: rich.style.StyleType = "dim yellow"
+STYLE_METAVAR_SEPARATOR: rich.style.StyleType = "dim"
+STYLE_HEADER_TEXT: rich.style.StyleType = ""
+STYLE_FOOTER_TEXT: rich.style.StyleType = ""
+STYLE_USAGE: rich.style.StyleType = "yellow"
+STYLE_USAGE_COMMAND: rich.style.StyleType = "bold"
+STYLE_DEPRECATED: rich.style.StyleType = "red"
+STYLE_HELPTEXT_FIRST_LINE: rich.style.StyleType = ""
+STYLE_HELPTEXT: rich.style.StyleType = "dim"
+STYLE_OPTION_HELP: rich.style.StyleType = ""
+STYLE_OPTION_DEFAULT: rich.style.StyleType = "dim"
+STYLE_OPTION_ENVVAR: rich.style.StyleType = "dim yellow"
+STYLE_REQUIRED_SHORT: rich.style.StyleType = "red"
+STYLE_REQUIRED_LONG: rich.style.StyleType = "dim red"
+STYLE_OPTIONS_PANEL_BORDER: rich.style.StyleType = "dim"
+ALIGN_OPTIONS_PANEL: rich.align.AlignMethod = "left"
+STYLE_OPTIONS_TABLE_SHOW_LINES: bool = False
+STYLE_OPTIONS_TABLE_LEADING: int = 0
+STYLE_OPTIONS_TABLE_PAD_EDGE: bool = False
+STYLE_OPTIONS_TABLE_PADDING: rich.padding.PaddingDimensions = (0, 1)
+STYLE_OPTIONS_TABLE_BOX: rich.style.StyleType = ""
+STYLE_OPTIONS_TABLE_ROW_STYLES: Optional[List[rich.style.StyleType]] = None
+STYLE_OPTIONS_TABLE_BORDER_STYLE: Optional[rich.style.StyleType] = None
+STYLE_COMMANDS_PANEL_BORDER: rich.style.StyleType = "dim"
+ALIGN_COMMANDS_PANEL: rich.align.AlignMethod = "left"
+STYLE_COMMANDS_TABLE_SHOW_LINES: bool = False
+STYLE_COMMANDS_TABLE_LEADING: int = 0
+STYLE_COMMANDS_TABLE_PAD_EDGE: bool = False
+STYLE_COMMANDS_TABLE_PADDING: rich.padding.PaddingDimensions = (0, 1)
+STYLE_COMMANDS_TABLE_BOX: rich.style.StyleType = ""
+STYLE_COMMANDS_TABLE_ROW_STYLES: Optional[List[rich.style.StyleType]] = None
+STYLE_COMMANDS_TABLE_BORDER_STYLE: Optional[rich.style.StyleType] = None
+STYLE_COMMANDS_TABLE_COLUMN_WIDTH_RATIO: Optional[Union[Tuple[None, None], Tuple[int, int]]] = (None, None)
+STYLE_ERRORS_PANEL_BORDER: rich.style.StyleType = "red"
+ALIGN_ERRORS_PANEL: rich.align.AlignMethod = "left"
+STYLE_ERRORS_SUGGESTION: rich.style.StyleType = "dim"
+STYLE_ABORTED: rich.style.StyleType = "red"
+WIDTH: Optional[int] = int(getenv("TERMINAL_WIDTH")) if getenv("TERMINAL_WIDTH") else None  # type: ignore[arg-type]
+MAX_WIDTH: Optional[int] = (
+    int(getenv("TERMINAL_WIDTH")) if getenv("TERMINAL_WIDTH") else WIDTH  # type: ignore[arg-type]
+)
 COLOR_SYSTEM: Optional[
     Literal["auto", "standard", "256", "truecolor", "windows"]
 ] = "auto"  # Set to None to disable colors
-FORCE_TERMINAL = True if getenv("GITHUB_ACTIONS") or getenv("FORCE_COLOR") or getenv("PY_COLORS") else None
+FORCE_TERMINAL: Optional[bool] = (
+    True if getenv("GITHUB_ACTIONS") or getenv("FORCE_COLOR") or getenv("PY_COLORS") else None
+)
 
 # Fixed strings
 HEADER_TEXT: Optional[str] = None
 FOOTER_TEXT: Optional[str] = None
-DEPRECATED_STRING = "(Deprecated) "
-DEFAULT_STRING = "[default: {}]"
-ENVVAR_STRING = "[env var: {}]"
-REQUIRED_SHORT_STRING = "*"
-REQUIRED_LONG_STRING = "[required]"
-RANGE_STRING = " [{}]"
-APPEND_METAVARS_HELP_STRING = "({})"
-ARGUMENTS_PANEL_TITLE = "Arguments"
-OPTIONS_PANEL_TITLE = "Options"
-COMMANDS_PANEL_TITLE = "Commands"
-ERRORS_PANEL_TITLE = "Error"
+DEPRECATED_STRING: str = "(Deprecated) "
+DEFAULT_STRING: str = "[default: {}]"
+ENVVAR_STRING: str = "[env var: {}]"
+REQUIRED_SHORT_STRING: str = "*"
+REQUIRED_LONG_STRING: str = "[required]"
+RANGE_STRING: str = " [{}]"
+APPEND_METAVARS_HELP_STRING: str = "({})"
+ARGUMENTS_PANEL_TITLE: str = "Arguments"
+OPTIONS_PANEL_TITLE: str = "Options"
+COMMANDS_PANEL_TITLE: str = "Commands"
+ERRORS_PANEL_TITLE: str = "Error"
 ERRORS_SUGGESTION: Optional[str] = None  # Default: Try 'cmd -h' for help. Set to False to disable.
 ERRORS_EPILOGUE: Optional[str] = None
-ABORTED_TEXT = "Aborted."
+ABORTED_TEXT: str = "Aborted."
 
 # Behaviours
-SHOW_ARGUMENTS = False  # Show positional arguments
-SHOW_METAVARS_COLUMN = True  # Show a column with the option metavar (eg. INTEGER)
-APPEND_METAVARS_HELP = False  # Append metavar (eg. [TEXT]) after the help text
-GROUP_ARGUMENTS_OPTIONS = False  # Show arguments with options instead of in own panel
-OPTION_ENVVAR_FIRST = False  # Show env vars before option help text instead of avert
-USE_MARKDOWN = False  # Parse help strings as markdown
-USE_MARKDOWN_EMOJI = True  # Parse emoji codes in markdown :smile:
-USE_RICH_MARKUP = False  # Parse help strings for rich markup (eg. [red]my text[/])
+SHOW_ARGUMENTS: bool = False  # Show positional arguments
+SHOW_METAVARS_COLUMN: bool = True  # Show a column with the option metavar (eg. INTEGER)
+APPEND_METAVARS_HELP: bool = False  # Append metavar (eg. [TEXT]) after the help text
+GROUP_ARGUMENTS_OPTIONS: bool = False  # Show arguments with options instead of in own panel
+OPTION_ENVVAR_FIRST: bool = False  # Show env vars before option help text instead of avert
+USE_MARKDOWN: bool = False  # Parse help strings as markdown
+USE_MARKDOWN_EMOJI: bool = True  # Parse emoji codes in markdown :smile:
+USE_RICH_MARKUP: bool = False  # Parse help strings for rich markup (eg. [red]my text[/])
 # Define sorted groups of panels to display subcommands
 COMMAND_GROUPS: Dict[str, List[Dict[str, Union[str, List[str]]]]] = {}
 # Define sorted groups of panels to display options and arguments
 OPTION_GROUPS: Dict[str, List[Dict[str, Union[str, List[str], Dict[str, List[str]]]]]] = {}
-USE_CLICK_SHORT_HELP = False  # Use click's default function to truncate help text
+USE_CLICK_SHORT_HELP: bool = False  # Use click's default function to truncate help text
 
-highlighter = OptionHighlighter()
-_formatter = None
+highlighter: rich.highlighter.Highlighter = OptionHighlighter()
+_formatter: Optional[RichHelpFormatter] = None
 
 
 def _get_rich_formatter(formatter: Optional[click.HelpFormatter] = None) -> RichHelpFormatter:
@@ -235,8 +239,8 @@ def _get_help_text(
         yield _make_rich_rext(remaining_lines, config.style_helptext, formatter)
 
 
-def _get_parameter_help(
-    param: Union[click.Option, click.Argument], ctx: click.Context, formatter: Optional[RichHelpFormatter] = None
+def _get_option_help(
+    param: Union[click.Argument, click.Option], ctx: click.Context, formatter: Optional[RichHelpFormatter] = None
 ) -> rich.columns.Columns:
     """Build primary help text for a click option or argument.
 
@@ -245,7 +249,7 @@ def _get_parameter_help(
     Additional elements are appended to show the default and required status if applicable.
 
     Args:
-        param (click.Option or click.Argument): Option or argument to build help text for
+        param (click.Argument or click.Option): Parameter to build help text for
         ctx (click.Context): Click Context object
 
     Returns:
@@ -254,6 +258,9 @@ def _get_parameter_help(
     formatter = _get_rich_formatter(formatter)
     config = formatter.config
     items: List[rich.console.RenderableType] = []
+
+    if TYPE_CHECKING:
+        assert isinstance(param.name, str)
 
     # Get the environment variable first
     envvar = getattr(param, "envvar", None)
@@ -275,6 +282,7 @@ def _get_parameter_help(
     # Main help text
     if getattr(param, "help", None):
         if TYPE_CHECKING:
+            assert isinstance(param, click.Option)
             assert hasattr(param, "help")
             assert isinstance(param.help, str)
         paragraphs = param.help.split("\n\n")
@@ -309,25 +317,31 @@ def _get_parameter_help(
 
     # Default value
     # Click 7.x, 8.0, and 8.1 all behave slightly differently when handling the default value help text.
-    if CLICK_IS_BEFORE_VERSION_8X:
-        parse_default = param.default is not None and (param.show_default or getattr(ctx, "show_default", None))
+    if not hasattr(param, "show_default"):
+        parse_default = False
+    elif CLICK_IS_BEFORE_VERSION_8X:
+        parse_default = bool(param.default is not None and (param.show_default or getattr(ctx, "show_default", None)))
     elif CLICK_IS_VERSION_80:
-        show_default_is_str = isinstance(getattr(param, "show_default", None), str)
-        parse_default = show_default_is_str or (param.default is not None and (param.show_default or ctx.show_default))
+        show_default_is_str = isinstance(param.show_default, str)
+        parse_default = bool(
+            show_default_is_str or (param.default is not None and (param.show_default or ctx.show_default))
+        )
     else:
-        show_default = False
         show_default_is_str = False
-        if getattr(param, "show_default", None) is not None:
+        if param.show_default is not None:
             if isinstance(param.show_default, str):
                 show_default_is_str = show_default = True
             else:
-                show_default = param.show_default
+                show_default = bool(param.show_default)
         else:
-            show_default = getattr(ctx, "show_default", False)
+            show_default = bool(getattr(ctx, "show_default", False))
         parse_default = bool(show_default_is_str or (show_default and (param.default is not None)))
 
     if parse_default:
-        default_str_match = re.search(r"\[(?:.+; )?default: (.*)\]", param.get_help_record(ctx)[-1])
+        help_record = param.get_help_record(ctx)
+        if TYPE_CHECKING:
+            assert isinstance(help_record, tuple)
+        default_str_match = re.search(r"\[(?:.+; )?default: (.*)\]", help_record[-1])
         if default_str_match:
             # Don't show the required string, as we show that afterwards anyway
             default_str = default_str_match.group(1).replace("; required", "")
@@ -381,7 +395,7 @@ def get_rich_usage(
     obj: Union[click.Command, click.Group],
     ctx: click.Context,
     formatter: click.HelpFormatter,
-):
+) -> None:
     """Get usage text for a command."""
     formatter = _get_rich_formatter(formatter)
     config = formatter.config
@@ -411,7 +425,7 @@ def get_rich_usage(
 
 
 def rich_format_help(
-    obj: click.BaseCommand,
+    obj: click.Command,
     ctx: click.Context,
     formatter: click.HelpFormatter,
 ) -> None:
@@ -481,13 +495,15 @@ def rich_format_help(
             if isinstance(param, click.core.Argument) and not config.group_arguments_options:
                 argument_group_options.append(param.opts[0])
             else:
-                list_of_option_groups: List = option_groups[-1]["options"]  # type: ignore
+                list_of_option_groups: List = option_groups[-1]["options"]  # type: ignore[assignment]
                 list_of_option_groups.append(param.opts[0])
 
     # If we're not grouping arguments and we got some, prepend before default options
     if len(argument_group_options) > 0:
         extra_option_group = {"name": config.arguments_panel_title, "options": argument_group_options}
-        option_groups.insert(len(option_groups) - 1, extra_option_group)  # type: ignore
+        option_groups.insert(len(option_groups) - 1, extra_option_group)
+
+    # print("!", option_groups)
 
     # Print each option group panel
     for option_group in option_groups:
@@ -522,12 +538,18 @@ def rich_format_help(
             metavar = Text(style=config.style_metavar, overflow="fold")
             metavar_str = param.make_metavar()
 
+            if TYPE_CHECKING:
+                assert isinstance(param.name, str)
+                assert isinstance(param, click.Option)
+
             # Do it ourselves if this is a positional argument
             if isinstance(param, click.core.Argument) and re.match(rf"\[?{param.name.upper()}]?", metavar_str):
                 metavar_str = param.type.name.upper()
 
             # Attach metavar if param is a positional argument, or if it is a non boolean and non flag option
-            if isinstance(param, click.core.Argument) or (metavar_str != "BOOLEAN" and not param.is_flag):
+            if isinstance(param, click.core.Argument) or (
+                metavar_str != "BOOLEAN" and not getattr(param, "is_flag", None)
+            ):
                 metavar.append(metavar_str)
 
             # Range - from
@@ -545,7 +567,7 @@ def rich_format_help(
                 pass
 
             # Required asterisk
-            required = ""
+            required: Union[Text, str] = ""
             if param.required:
                 required = Text(config.required_short_string, style=config.style_required_short)
 
@@ -564,7 +586,7 @@ def rich_format_help(
                 highlighter(highlighter(",".join(opt_long_strs))),
                 highlighter(highlighter(",".join(opt_short_strs))),
                 metavar_highlighter(metavar),
-                _get_parameter_help(param, ctx, formatter),
+                _get_option_help(param, ctx, formatter),
             ]
 
             # Remove metavar if specified in config
@@ -583,8 +605,8 @@ def rich_format_help(
                 "pad_edge": config.style_options_table_pad_edge,
                 "padding": config.style_options_table_padding,
             }
-            t_styles.update(option_group.get("table_styles", {}))  # type: ignore
-            box_style = getattr(box, t_styles.pop("box"), None)  # type: ignore
+            t_styles.update(option_group.get("table_styles", {}))  # type: ignore[arg-type]
+            box_style = getattr(box, t_styles.pop("box"), None)  # type: ignore[arg-type]
 
             options_table = Table(
                 highlight=True,
@@ -621,7 +643,7 @@ def rich_format_help(
                 if command in cmd_group.get("commands", []):
                     break
             else:
-                commands: List = cmd_groups[-1]["commands"]  # type: ignore
+                commands: List = cmd_groups[-1]["commands"]  # type: ignore[assignment]
                 commands.append(command)
 
         # Print each command group panel
@@ -635,8 +657,8 @@ def rich_format_help(
                 "pad_edge": config.style_commands_table_pad_edge,
                 "padding": config.style_commands_table_padding,
             }
-            t_styles.update(cmd_group.get("table_styles", {}))  # type: ignore
-            box_style = getattr(box, t_styles.pop("box"), None)  # type: ignore
+            t_styles.update(cmd_group.get("table_styles", {}))  # type: ignore[arg-type]
+            box_style = getattr(box, t_styles.pop("box"), None)  # type: ignore[arg-type]
 
             commands_table = Table(
                 highlight=False,
@@ -647,20 +669,23 @@ def rich_format_help(
             )
             # Define formatting in first column, as commands don't match highlighter regex
             # and set column ratio for first and second column, if a ratio has been set
-            commands_table.add_column(
-                style="bold cyan",
-                no_wrap=True,
-                ratio=STYLE_COMMANDS_TABLE_COLUMN_WIDTH_RATIO[0],
-            )
+            if config.style_commands_table_column_width_ratio is None:
+                table_column_width_ratio: Union[Tuple[None, None], Tuple[int, int]] = (None, None)
+            else:
+                table_column_width_ratio = config.style_commands_table_column_width_ratio
+
+            commands_table.add_column(style="bold cyan", no_wrap=True, ratio=table_column_width_ratio[0])
             commands_table.add_column(
                 no_wrap=False,
-                ratio=STYLE_COMMANDS_TABLE_COLUMN_WIDTH_RATIO[1],
+                ratio=table_column_width_ratio[1],
             )
             for command in cmd_group.get("commands", []):
                 # Skip if command does not exist
                 if command not in obj.list_commands(ctx):
                     continue
                 cmd = obj.get_command(ctx, command)
+                if TYPE_CHECKING:
+                    assert cmd is not None
                 if cmd.hidden:
                     continue
                 # Use the truncated short text as with vanilla text if requested

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -495,7 +495,7 @@ def rich_format_help(
             if isinstance(param, click.core.Argument) and not config.group_arguments_options:
                 argument_group_options.append(param.opts[0])
             else:
-                list_of_option_groups: List = option_groups[-1]["options"]  # type: ignore[assignment]
+                list_of_option_groups: List[str] = option_groups[-1]["options"]  # type: ignore[assignment]
                 list_of_option_groups.append(param.opts[0])
 
     # If we're not grouping arguments and we got some, prepend before default options
@@ -643,7 +643,7 @@ def rich_format_help(
                 if command in cmd_group.get("commands", []):
                     break
             else:
-                commands: List = cmd_groups[-1]["commands"]  # type: ignore[assignment]
+                commands: List[str] = cmd_groups[-1]["commands"]  # type: ignore[assignment]
                 commands.append(command)
 
         # Print each command group panel
@@ -717,7 +717,7 @@ def rich_format_help(
         console.print(Padding(_make_rich_rext(config.footer_text, config.style_footer_text, formatter), (1, 1, 0, 1)))
 
 
-def rich_format_error(self: click.ClickException, formatter: Optional[RichHelpFormatter] = None):
+def rich_format_error(self: click.ClickException, formatter: Optional[RichHelpFormatter] = None) -> None:
     """Print richly formatted click errors.
 
     Called by custom exception handler to print richly formatted click errors.

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -7,10 +7,12 @@ from typing import Any, Callable, cast, Optional, overload, Sequence, TextIO, Ty
 
 import click
 from click.utils import make_str, PacifyFlushWrapper
+from rich.console import Console
 
 from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
 from rich_click.rich_click import rich_abort_error, rich_format_error, rich_format_help
 from rich_click.rich_context import RichContext
+from rich_click.rich_help_configuration import RichHelpConfiguration
 from rich_click.rich_help_formatter import RichHelpFormatter
 
 
@@ -41,7 +43,7 @@ class RichCommand(click.Command):
                 del self.callback.__rich_context_settings__
 
     @property
-    def console(self):
+    def console(self) -> Optional[Console]:
         """Rich Console.
 
         This is a separate instance from the help formatter that allows full control of the
@@ -52,7 +54,7 @@ class RichCommand(click.Command):
         return self.context_settings.get("rich_console")
 
     @property
-    def help_config(self):
+    def help_config(self) -> Optional[RichHelpConfiguration]:
         """Rich Help Configuration."""
         return self.context_settings.get("rich_help_config")
 
@@ -156,7 +158,7 @@ class RichCommand(click.Command):
             sys.stderr.write(self.formatter.getvalue())
             sys.exit(1)
 
-    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter):
+    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         rich_format_help(self, ctx, formatter)
 
 
@@ -171,7 +173,7 @@ with warnings.catch_warnings():
         """
 
     @wraps(click.MultiCommand.__init__)
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # type: ignore[no-untyped-def]
         """Initialize RichGroup class."""
         click.MultiCommand.__init__(self, *args, **kwargs)
         self._register_rich_context_settings_from_callback()
@@ -188,7 +190,7 @@ class RichGroup(RichCommand, click.Group):
     group_class = type
 
     @wraps(click.Group.__init__)
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize RichGroup class."""
         click.Group.__init__(self, *args, **kwargs)
         self._register_rich_context_settings_from_callback()
@@ -209,4 +211,4 @@ class RichGroup(RichCommand, click.Group):
             # This method override is required for Click 7.x compatibility.
             # (The command_class ClassVar was not added until 8.0.)
             kwargs.setdefault("cls", self.command_class)
-            return super().command(*args, **kwargs)
+            return super().command(*args, **kwargs)  # type: ignore[no-any-return]

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -30,10 +30,14 @@ class RichCommand(click.Command):
     def __init__(self, *args: Any, **kwargs: Any):
         """Create Rich Command instance."""
         super().__init__(*args, **kwargs)
+        self._register_rich_context_settings_from_callback()
+
+    def _register_rich_context_settings_from_callback(self) -> None:
         if self.callback is not None:
             if hasattr(self.callback, "__rich_context_settings__"):
                 rich_context_settings = getattr(self.callback, "__rich_context_settings__", {})
-                self.context_settings.update(rich_context_settings)
+                for k, v in rich_context_settings.items():
+                    self.context_settings.setdefault(k, v)
                 del self.callback.__rich_context_settings__
 
     @property
@@ -166,6 +170,12 @@ with warnings.catch_warnings():
         to print richly formatted output.
         """
 
+    @wraps(click.MultiCommand.__init__)
+    def __init__(self, *args, **kwargs):
+        """Initialize RichGroup class."""
+        click.MultiCommand.__init__(self, *args, **kwargs)
+        self._register_rich_context_settings_from_callback()
+
 
 class RichGroup(RichCommand, click.Group):
     """Richly formatted click Group.
@@ -176,6 +186,12 @@ class RichGroup(RichCommand, click.Group):
 
     command_class: Type[RichCommand] = RichCommand
     group_class = type
+
+    @wraps(click.Group.__init__)
+    def __init__(self, *args, **kwargs):
+        """Initialize RichGroup class."""
+        click.Group.__init__(self, *args, **kwargs)
+        self._register_rich_context_settings_from_callback()
 
     if CLICK_IS_BEFORE_VERSION_8X:
 

--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -42,4 +42,6 @@ class RichContext(click.Context):
 
     def make_formatter(self):
         """Create the Rich Help Formatter."""
-        return self.formatter_class(config=self.help_config)
+        return self.formatter_class(
+            width=self.terminal_width, max_width=self.max_content_width, config=self.help_config
+        )

--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Type
+from typing import Optional, Type
 
 import click
 from rich.console import Console
@@ -10,7 +10,7 @@ from rich_click.rich_help_formatter import RichHelpFormatter
 class RichContext(click.Context):
     """Click Context class endowed with Rich superpowers."""
 
-    formatter_class: ClassVar[Type[RichHelpFormatter]] = RichHelpFormatter
+    formatter_class: Type[RichHelpFormatter] = RichHelpFormatter
 
     def __init__(
         self,

--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -28,24 +28,17 @@ class RichContext(click.Context):
                 Defaults to None.
         """
         super().__init__(*args, **kwargs)
-        self._console = rich_console
-        self._help_config = rich_help_config
+        parent: Optional[RichContext] = kwargs.pop("parent", None)
 
-    @property
-    def console(self) -> Optional[Console]:
-        """Rich Console instance for displaying beautfil application output in the terminal.
+        if rich_console is None and hasattr(parent, "console"):
+            rich_console = parent.console  # type: ignore[has-type,union-attr]
 
-        NOTE: This is a separate instance from the one used by the help formatter, and allows full control of the
-        console configuration.
+        self.console = rich_console
 
-        See `rich_config` decorator for how to apply the settings.
-        """
-        return self._console
+        if rich_help_config is None and hasattr(parent, "help_config"):
+            rich_help_config = parent.help_config  # type: ignore[has-type,union-attr]
 
-    @property
-    def help_config(self) -> Optional[RichHelpConfiguration]:
-        """Rich help configuration."""
-        return self._help_config
+        self.help_config = rich_help_config
 
     def make_formatter(self):
         """Create the Rich Help Formatter."""

--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type
+from typing import Any, Optional, Type
 
 import click
 from rich.console import Console
@@ -14,10 +14,10 @@ class RichContext(click.Context):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         rich_console: Optional[Console] = None,
         rich_help_config: Optional[RichHelpConfiguration] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Create Rich Context instance.
 

--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -40,7 +40,7 @@ class RichContext(click.Context):
 
         self.help_config = rich_help_config
 
-    def make_formatter(self):
+    def make_formatter(self) -> RichHelpFormatter:
         """Create the Rich Help Formatter."""
         return self.formatter_class(
             width=self.terminal_width, max_width=self.max_content_width, config=self.help_config

--- a/src/rich_click/rich_help_configuration.py
+++ b/src/rich_click/rich_help_configuration.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from os import getenv
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import rich.align
 import rich.color
@@ -65,7 +65,7 @@ class RichHelpConfiguration:
     style_commands_table_box: rich.style.StyleType = field(default="")
     style_commands_table_row_styles: Optional[List[rich.style.StyleType]] = field(default=None)
     style_commands_table_border_style: Optional[rich.style.StyleType] = field(default=None)
-    style_commands_table_column_width_ratio: Optional[rich.style.StyleType] = field(
+    style_commands_table_column_width_ratio: Optional[Union[Tuple[None, None], Tuple[int, int]]] = field(
         default_factory=lambda: (None, None)
     )
     style_errors_panel_border: rich.style.StyleType = field(default="red")

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -1,6 +1,6 @@
 import sys
 from io import StringIO
-from typing import IO, Optional
+from typing import Any, IO, Optional
 
 import click
 import rich
@@ -80,9 +80,12 @@ class RichHelpFormatter(click.HelpFormatter):
 
     def __init__(
         self,
-        *args,
+        indent_increment: int = 2,
+        width: Optional[int] = None,
+        max_width: Optional[int] = None,
+        *args: Any,
         config: Optional[RichHelpConfiguration] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Create Rich Help Formatter.
 
@@ -90,7 +93,7 @@ class RichHelpFormatter(click.HelpFormatter):
             config: Configuration.
                 Defaults to None.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(indent_increment, width, max_width, *args, **kwargs)
         self._rich_buffer = TerminalBuffer()
         self._config = config or get_module_config()
         self._console = create_console(self._config, self._rich_buffer)

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -66,7 +66,7 @@ def get_module_config() -> RichHelpConfiguration:
     A function-level import is used to avoid a circular dependency
     between the formatter and formatter operations.
     """
-    from rich_click.rich_click import get_module_help_configuration  # type: ignore
+    from rich_click.rich_click import get_module_help_configuration
 
     return get_module_help_configuration()
 

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -93,6 +93,10 @@ class RichHelpFormatter(click.HelpFormatter):
             config: Configuration.
                 Defaults to None.
         """
+        if config is not None:
+            # Rich config overrides width and max width if set.
+            width = config.width or width
+            max_width = config.max_width or max_width
         super().__init__(indent_increment, width, max_width, *args, **kwargs)
         self._rich_buffer = TerminalBuffer()
         self._config = config or get_module_config()

--- a/tests/fixtures/arguments.py
+++ b/tests/fixtures/arguments.py
@@ -16,7 +16,7 @@ click.rich_click.SHOW_ARGUMENTS = True
 )
 @click.option("--all", is_flag=True, help="Sync all the things?")
 @click.option("--debug", is_flag=True, help="Enable debug mode")
-def cli(input, type, all, debug):
+def cli(input: str, type: str, all: bool, debug: bool) -> None:
     """
     My amazing tool does all the things.
 

--- a/tests/fixtures/context_settings.py
+++ b/tests/fixtures/context_settings.py
@@ -10,7 +10,7 @@ import rich_click as click
     show_default="show me in c8+",
     help="Show 'default: (show me in c8+)' in click>=8.0. In click 7, no default is shown.",
 )
-def cli(a: str, b: str, c: str, d: str):
+def cli(a: str, b: str, c: str, d: str) -> None:
     """
     Test cases for context_settings.
 

--- a/tests/fixtures/context_settings.py
+++ b/tests/fixtures/context_settings.py
@@ -10,7 +10,7 @@ import rich_click as click
     show_default="show me in c8+",
     help="Show 'default: (show me in c8+)' in click>=8.0. In click 7, no default is shown.",
 )
-def cli(a, b, c, d):
+def cli(a: str, b: str, c: str, d: str):
     """
     Test cases for context_settings.
 

--- a/tests/fixtures/custom_errors.py
+++ b/tests/fixtures/custom_errors.py
@@ -18,7 +18,7 @@ click.rich_click.ERRORS_EPILOGUE = "To find out more, visit [link=https://mytool
 )
 @click.option("--all", is_flag=True, help="Sync all the things?")
 @click.option("--debug", is_flag=True, default=False, help="Enable debug mode")
-def cli(input, type, all, debug):
+def cli(input, type, all, debug) -> None:
     """
     My amazing tool does all the things.
 

--- a/tests/fixtures/custom_errors.py
+++ b/tests/fixtures/custom_errors.py
@@ -18,7 +18,7 @@ click.rich_click.ERRORS_EPILOGUE = "To find out more, visit [link=https://mytool
 )
 @click.option("--all", is_flag=True, help="Sync all the things?")
 @click.option("--debug", is_flag=True, default=False, help="Enable debug mode")
-def cli(input, type, all, debug) -> None:
+def cli(input: str, type: str, all: bool, debug: bool) -> None:
     """
     My amazing tool does all the things.
 

--- a/tests/fixtures/declarative.py
+++ b/tests/fixtures/declarative.py
@@ -1,11 +1,11 @@
 import click
 
-from rich_click import RichCommand, RichGroup
+from rich_click import pass_context, RichCommand, RichContext, RichGroup
 
 
 @click.group(cls=RichGroup)
 @click.option("--debug/--no-debug", default=False)
-def cli(debug):
+def cli(debug) -> None:
     """
     My amazing tool does all the things.
 
@@ -19,7 +19,8 @@ def cli(debug):
 
 
 @cli.command(cls=RichCommand)
-def sync():
+@pass_context
+def sync(ctx: RichContext) -> None:
     """Synchronise all your files between two places."""
     click.echo("Syncing")
 

--- a/tests/fixtures/declarative.py
+++ b/tests/fixtures/declarative.py
@@ -5,7 +5,7 @@ from rich_click import pass_context, RichCommand, RichContext, RichGroup
 
 @click.group(cls=RichGroup)
 @click.option("--debug/--no-debug", default=False)
-def cli(debug) -> None:
+def cli(debug: bool) -> None:
     """
     My amazing tool does all the things.
 

--- a/tests/fixtures/envvar.py
+++ b/tests/fixtures/envvar.py
@@ -8,7 +8,7 @@ import rich_click as click
 
 @click.group(context_settings=dict(auto_envvar_prefix="GREETER"))
 @click.option("--debug/--no-debug")
-def cli(debug):
+def cli(debug) -> None:
     click.echo(f"Debug mode is {'on' if debug else 'off'}")
 
 
@@ -29,7 +29,7 @@ def cli(debug):
     show_default=True,
     help="This can be set via env var EMAIL or EMAIL_ADDRESS",
 )
-def greet(username, nickname, email):
+def greet(username, nickname, email) -> None:
     click.echo(f"Hello {username} ({nickname}) with email {email}!")
 
 

--- a/tests/fixtures/envvar.py
+++ b/tests/fixtures/envvar.py
@@ -8,7 +8,7 @@ import rich_click as click
 
 @click.group(context_settings=dict(auto_envvar_prefix="GREETER"))
 @click.option("--debug/--no-debug")
-def cli(debug) -> None:
+def cli(debug: bool) -> None:
     click.echo(f"Debug mode is {'on' if debug else 'off'}")
 
 
@@ -29,7 +29,7 @@ def cli(debug) -> None:
     show_default=True,
     help="This can be set via env var EMAIL or EMAIL_ADDRESS",
 )
-def greet(username, nickname, email) -> None:
+def greet(username: str, nickname: str, email: str) -> None:
     click.echo(f"Hello {username} ({nickname}) with email {email}!")
 
 

--- a/tests/fixtures/groups_sorting.py
+++ b/tests/fixtures/groups_sorting.py
@@ -56,7 +56,7 @@ click.rich_click.COMMAND_GROUPS = {
     help="Show the debug log messages",
 )
 @click.version_option("1.23", prog_name="mytool")
-def cli(type, debug):
+def cli(type: str, debug: bool) -> None:
     """
     My amazing tool does all the things.
 
@@ -70,30 +70,30 @@ def cli(type, debug):
 
 
 @cli.command()
-@click.option("--input", "-i", required=True, help="Input path")
+@click.option("--input", "-i", "input_", required=True, help="Input path")
 @click.option("--output", "-o", help="Output path")
-@click.option("--all", is_flag=True, help="Sync all the things?")
+@click.option("--all", "all_", is_flag=True, help="Sync all the things?")
 @click.option("--overwrite", is_flag=True, help="Overwrite local files")
-def sync(input, output, all, overwrite):
+def sync(input_: str, output: str, all_: bool, overwrite: bool) -> None:
     """Synchronise all your files between two places."""
     print("Syncing")
 
 
 @cli.command()
 @click.option("--all", is_flag=True, help="Get everything")
-def download(all):
+def download(all: bool) -> None:
     """Pretend to download some files from somewhere."""
     print("Downloading")
 
 
 @cli.command()
-def auth():
+def auth() -> None:
     """Authenticate the app."""
     print("Downloading")
 
 
 @cli.command()
-def config():
+def config() -> None:
     """Set up the configuration."""
     print("Downloading")
 

--- a/tests/fixtures/markdown.py
+++ b/tests/fixtures/markdown.py
@@ -18,7 +18,7 @@ click.rich_click.USE_MARKDOWN = True
 )
 @click.option("--all", is_flag=True, help="Sync\n 1. all\n 2. the\n 3. things?")
 @click.option("--debug", is_flag=True, help="# Enable `debug mode`")
-def cli(input, type, all, debug):
+def cli(input, type, all, debug) -> None:
     """
     My amazing tool does _**all the things**_.
 

--- a/tests/fixtures/markdown.py
+++ b/tests/fixtures/markdown.py
@@ -18,7 +18,7 @@ click.rich_click.USE_MARKDOWN = True
 )
 @click.option("--all", is_flag=True, help="Sync\n 1. all\n 2. the\n 3. things?")
 @click.option("--debug", is_flag=True, help="# Enable `debug mode`")
-def cli(input, type, all, debug) -> None:
+def cli(input: str, type: str, all: bool, debug: bool) -> None:
     """
     My amazing tool does _**all the things**_.
 

--- a/tests/fixtures/metavars.py
+++ b/tests/fixtures/metavars.py
@@ -45,7 +45,7 @@ click.rich_click.APPEND_METAVARS_HELP = True
     show_default=True,
     help="This click choice has loads of options.",
 )
-def cli(debug, number):
+def cli(debug, number) -> None:
     """
     My amazing tool does all the things.
 

--- a/tests/fixtures/metavars.py
+++ b/tests/fixtures/metavars.py
@@ -45,7 +45,7 @@ click.rich_click.APPEND_METAVARS_HELP = True
     show_default=True,
     help="This click choice has loads of options.",
 )
-def cli(debug, number) -> None:
+def cli(debug: bool, number: str) -> None:
     """
     My amazing tool does all the things.
 

--- a/tests/fixtures/metavars_default.py
+++ b/tests/fixtures/metavars_default.py
@@ -1,7 +1,7 @@
 import rich_click as click
 
 
-@click.command()
+@click.command("cli")
 @click.option("--debug", is_flag=True, help="Enable debug mode.")
 @click.option(
     "--number",
@@ -42,7 +42,7 @@ import rich_click as click
     show_default=True,
     help="This click choice has loads of options.",
 )
-def cli(debug, number):
+def cli(debug, number) -> None:
     """
     My amazing tool does all the things.
 

--- a/tests/fixtures/metavars_default.py
+++ b/tests/fixtures/metavars_default.py
@@ -42,7 +42,7 @@ import rich_click as click
     show_default=True,
     help="This click choice has loads of options.",
 )
-def cli(debug, number) -> None:
+def cli(debug: bool, number: str) -> None:
     """
     My amazing tool does all the things.
 

--- a/tests/fixtures/rich_markup.py
+++ b/tests/fixtures/rich_markup.py
@@ -4,7 +4,7 @@ import rich_click as click
 click.rich_click.USE_RICH_MARKUP = True
 
 
-@click.command()
+@click.command
 @click.option(
     "--input",
     type=click.Path(),

--- a/tests/fixtures/rich_markup.py
+++ b/tests/fixtures/rich_markup.py
@@ -18,7 +18,7 @@ click.rich_click.USE_RICH_MARKUP = True
 )
 @click.option("--all", is_flag=True, help="Sync all the things?")
 @click.option("--debug", is_flag=True, help="Enable :point_right: [yellow]debug mode[/] :point_left:")
-def cli(input, type, all, debug):
+def cli(input: str, type: str, all: bool, debug: bool) -> None:
     """
     My amazing tool does [black on blue] all the things [/].
 

--- a/tests/fixtures/simple.py
+++ b/tests/fixtures/simple.py
@@ -1,7 +1,7 @@
 import rich_click as click
 
 
-@click.group()
+@click.group
 @click.option(
     "--debug/--no-debug",
     "-d/-n",
@@ -11,7 +11,7 @@ import rich_click as click
 
     Double newlines are preserved.""",
 )
-def cli(debug):
+def cli(debug) -> None:
     """
     My amazing tool does all the things.
 
@@ -24,7 +24,7 @@ def cli(debug):
     print(f"Debug mode is {'on' if debug else 'off'}")
 
 
-@cli.command()
+@cli.command
 @click.option(
     "--type",
     required=True,
@@ -33,7 +33,7 @@ def cli(debug):
     help="Type of file to sync",
 )
 @click.option("--all", is_flag=True)
-def sync(type, all):
+def sync(type, all) -> None:
     """Synchronise all your files between two places.
     Example command that doesn't do much except print to the terminal."""
     print("Syncing")
@@ -41,7 +41,7 @@ def sync(type, all):
 
 @cli.command(short_help="Optionally use short-help for the group help text")
 @click.option("--all", is_flag=True, help="Get everything")
-def download(all):
+def download(all) -> None:
     """
     Pretend to download some files from
     somewhere. Multi-line help strings are unwrapped

--- a/tests/fixtures/simple.py
+++ b/tests/fixtures/simple.py
@@ -1,7 +1,7 @@
 import rich_click as click
 
 
-@click.group
+@click.group()
 @click.option(
     "--debug/--no-debug",
     "-d/-n",
@@ -24,7 +24,7 @@ def cli(debug) -> None:
     print(f"Debug mode is {'on' if debug else 'off'}")
 
 
-@cli.command
+@cli.command()
 @click.option(
     "--type",
     required=True,

--- a/tests/fixtures/simple.py
+++ b/tests/fixtures/simple.py
@@ -11,7 +11,7 @@ import rich_click as click
 
     Double newlines are preserved.""",
 )
-def cli(debug) -> None:
+def cli(debug: bool) -> None:
     """
     My amazing tool does all the things.
 
@@ -33,7 +33,7 @@ def cli(debug) -> None:
     help="Type of file to sync",
 )
 @click.option("--all", is_flag=True)
-def sync(type, all) -> None:
+def sync(type: str, all: bool) -> None:
     """Synchronise all your files between two places.
     Example command that doesn't do much except print to the terminal."""
     print("Syncing")
@@ -41,7 +41,7 @@ def sync(type, all) -> None:
 
 @cli.command(short_help="Optionally use short-help for the group help text")
 @click.option("--all", is_flag=True, help="Get everything")
-def download(all) -> None:
+def download(all: bool) -> None:
     """
     Pretend to download some files from
     somewhere. Multi-line help strings are unwrapped

--- a/tests/fixtures/table_alignment.py
+++ b/tests/fixtures/table_alignment.py
@@ -59,7 +59,7 @@ click.rich_click.COMMAND_GROUPS = {
     help="Show the debug log messages",
 )
 @click.version_option("1.23", prog_name="mytool")
-def cli(type, debug) -> None:
+def cli(type: str, debug: bool) -> None:
     """
     My amazing tool does all the things.
 
@@ -77,7 +77,7 @@ def cli(type, debug) -> None:
 @click.option("--output", "-o", help="Output path")
 @click.option("--all", is_flag=True, help="Sync all the things?")
 @click.option("--overwrite", is_flag=True, help="Overwrite local files")
-def sync(input, output, all, overwrite) -> None:
+def sync(input: str, output: str, all: bool, overwrite: bool) -> None:
     """Synchronise all your files between two places."""
     print("Syncing")
 
@@ -87,7 +87,7 @@ def sync(input, output, all, overwrite) -> None:
 
 @cli.command()
 @click.option("--all", is_flag=True, help="Get everything")
-def download(all) -> None:
+def download(all: bool) -> None:
     """Pretend to download some files from somewhere."""
     print("Downloading")
 

--- a/tests/fixtures/table_alignment.py
+++ b/tests/fixtures/table_alignment.py
@@ -58,7 +58,7 @@ click.rich_click.COMMAND_GROUPS = {
     help="Show the debug log messages",
 )
 @click.version_option("1.23", prog_name="mytool")
-def cli(type, debug):
+def cli(type, debug) -> None:
     """
     My amazing tool does all the things.
 
@@ -76,26 +76,29 @@ def cli(type, debug):
 @click.option("--output", "-o", help="Output path")
 @click.option("--all", is_flag=True, help="Sync all the things?")
 @click.option("--overwrite", is_flag=True, help="Overwrite local files")
-def sync(input, output, all, overwrite):
+def sync(input, output, all, overwrite) -> None:
     """Synchronise all your files between two places."""
     print("Syncing")
 
 
+# We vary the typing for cli.command() function a bit to test the function signature overloading
+
+
 @cli.command()
 @click.option("--all", is_flag=True, help="Get everything")
-def download(all):
+def download(all) -> None:
     """Pretend to download some files from somewhere."""
     print("Downloading")
 
 
-@cli.command()
-def auth():
+@cli.command("auth")
+def auth() -> None:
     """Authenticate the app."""
     print("Downloading")
 
 
-@cli.command()
-def config():
+@cli.command
+def config() -> None:
     """Set up the configuration."""
     print("Downloading")
 

--- a/tests/fixtures/table_alignment.py
+++ b/tests/fixtures/table_alignment.py
@@ -1,4 +1,5 @@
 import rich_click as click
+from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
 
 click.rich_click.STYLE_COMMANDS_TABLE_COLUMN_WIDTH_RATIO = (1, 2)
 
@@ -97,7 +98,13 @@ def auth() -> None:
     print("Downloading")
 
 
-@cli.command
+if CLICK_IS_BEFORE_VERSION_8X:
+    cmd_dec = cli.command()
+else:
+    cmd_dec = cli.command
+
+
+@cmd_dec
 def config() -> None:
     """Set up the configuration."""
     print("Downloading")

--- a/tests/fixtures/table_alignment.py
+++ b/tests/fixtures/table_alignment.py
@@ -1,5 +1,5 @@
 import rich_click as click
-from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
+from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X, CLICK_IS_VERSION_80
 
 click.rich_click.STYLE_COMMANDS_TABLE_COLUMN_WIDTH_RATIO = (1, 2)
 
@@ -98,7 +98,7 @@ def auth() -> None:
     print("Downloading")
 
 
-if CLICK_IS_BEFORE_VERSION_8X:
+if CLICK_IS_BEFORE_VERSION_8X or CLICK_IS_VERSION_80:
     cmd_dec = cli.command()
 else:
     cmd_dec = cli.command

--- a/tests/fixtures/table_styles.py
+++ b/tests/fixtures/table_styles.py
@@ -55,7 +55,7 @@ click.rich_click.STYLE_COMMANDS_TABLE_ROW_STYLES = ["magenta", "yellow", "cyan",
     """,
 )
 @click.version_option("1.23", prog_name="mytool")
-def cli(type, debug):
+def cli(type: str, debug: bool) -> None:
     """
     My amazing tool does all the things.
 
@@ -73,7 +73,7 @@ def cli(type, debug):
 @click.option("--output", "-o", help="Output path")
 @click.option("--all", is_flag=True, help="Sync all the things?")
 @click.option("--overwrite", is_flag=True, help="Overwrite local files")
-def sync(input, output, all, overwrite):
+def sync(input: str, output: str, all: bool, overwrite: bool) -> None:
     """
     Synchronise all your files between two places.
     Curabitur congue eget lorem in lacinia.
@@ -96,7 +96,7 @@ def sync(input, output, all, overwrite):
 
 @cli.command()
 @click.option("--all", is_flag=True, help="Get everything")
-def download(all):
+def download(all: bool) -> None:
     """
     Pretend to download some files from somewhere.
     Integer bibendum libero nunc, sed aliquet ex tincidunt vel.
@@ -112,7 +112,7 @@ def download(all):
 
 
 @cli.command()
-def auth():
+def auth() -> None:
     """
     Authenticate the app.
     Duis lacus nibh, feugiat a nibh a, commodo dictum libero.
@@ -128,7 +128,7 @@ def auth():
 
 
 @cli.command()
-def config():
+def config() -> None:
     """
     Set up the configuration.
     Sed accumsan ornare odio dictum aliquam.

--- a/tests/fixtures/table_styles.py
+++ b/tests/fixtures/table_styles.py
@@ -10,7 +10,7 @@ click.rich_click.STYLE_COMMANDS_TABLE_BORDER_STYLE = "red"
 click.rich_click.STYLE_COMMANDS_TABLE_ROW_STYLES = ["magenta", "yellow", "cyan", "green"]
 
 
-@click.group()
+@click.group("cli")
 @click.option(
     "--type",
     default="files",

--- a/tests/test_exit_code.py
+++ b/tests/test_exit_code.py
@@ -1,8 +1,10 @@
 import sys
 
+import pytest
 from click.testing import CliRunner
 
 from rich_click import command, group, pass_context, RichContext
+from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
 
 # Don't use the 'invoke' fixture because we want control over the standalone_mode kwarg.
 
@@ -90,6 +92,7 @@ def test_group_return_value_does_not_raise_exit_code():
     assert res.exit_code == 0
 
 
+@pytest.mark.skipif(CLICK_IS_BEFORE_VERSION_8X, reason="Result does not have return_value attribute.")
 def test_command_return_value_is_exit_code_when_not_standalone():
     for expected_exit_code in range(10):
 
@@ -103,6 +106,7 @@ def test_command_return_value_is_exit_code_when_not_standalone():
         assert res.return_value == expected_exit_code
 
 
+@pytest.mark.skipif(CLICK_IS_BEFORE_VERSION_8X, reason="Result does not have return_value attribute.")
 def test_group_return_value_is_exit_code_when_not_standalone():
     for expected_exit_code in range(10):
 

--- a/tests/test_exit_code.py
+++ b/tests/test_exit_code.py
@@ -1,5 +1,6 @@
 import sys
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -9,12 +10,12 @@ from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
 # Don't use the 'invoke' fixture because we want control over the standalone_mode kwarg.
 
 
-def test_command_exit_code_with_context():
+def test_command_exit_code_with_context() -> None:
     for expected_exit_code in range(10):
 
         @command("cli")
         @pass_context
-        def cli(ctx: RichContext):
+        def cli(ctx: RichContext) -> None:
             ctx.exit(expected_exit_code)
 
         runner = CliRunner()
@@ -40,11 +41,11 @@ def test_group_exit_code_with_context():
         assert res.exit_code == expected_exit_code
 
 
-def test_command_exit_code_with_sys_exit():
+def test_command_exit_code_with_sys_exit() -> None:
     for expected_exit_code in range(10):
 
         @command("cli")
-        def cli():
+        def cli() -> None:
             sys.exit(expected_exit_code)
 
         runner = CliRunner()
@@ -52,15 +53,15 @@ def test_command_exit_code_with_sys_exit():
         assert res.exit_code == expected_exit_code
 
 
-def test_group_exit_code_with_sys_exit():
+def test_group_exit_code_with_sys_exit() -> None:
     for expected_exit_code in range(10):
 
         @group("cli")
-        def cli():
+        def cli() -> None:
             sys.exit(expected_exit_code)
 
         @cli.command("subcommand")
-        def subcommand():
+        def subcommand() -> None:
             sys.exit(999)
 
         runner = CliRunner()
@@ -68,9 +69,9 @@ def test_group_exit_code_with_sys_exit():
         assert res.exit_code == expected_exit_code
 
 
-def test_command_return_value_does_not_raise_exit_code():
+def test_command_return_value_does_not_raise_exit_code() -> None:
     @command("cli")
-    def cli():
+    def cli() -> int:
         return 5
 
     runner = CliRunner()
@@ -78,13 +79,13 @@ def test_command_return_value_does_not_raise_exit_code():
     assert res.exit_code == 0
 
 
-def test_group_return_value_does_not_raise_exit_code():
+def test_group_return_value_does_not_raise_exit_code() -> None:
     @group("cli")
-    def cli():
+    def cli() -> int:
         return 5
 
     @cli.command("subcommand")
-    def subcommand():
+    def subcommand() -> int:
         return 10
 
     runner = CliRunner()
@@ -93,12 +94,12 @@ def test_group_return_value_does_not_raise_exit_code():
 
 
 @pytest.mark.skipif(CLICK_IS_BEFORE_VERSION_8X, reason="Result does not have return_value attribute.")
-def test_command_return_value_is_exit_code_when_not_standalone():
+def test_command_return_value_is_exit_code_when_not_standalone() -> None:
     for expected_exit_code in range(10):
 
         @command("cli")
         @pass_context
-        def cli(ctx: RichContext):
+        def cli(ctx: click.Context) -> None:
             ctx.exit(expected_exit_code)
 
         runner = CliRunner()
@@ -107,17 +108,17 @@ def test_command_return_value_is_exit_code_when_not_standalone():
 
 
 @pytest.mark.skipif(CLICK_IS_BEFORE_VERSION_8X, reason="Result does not have return_value attribute.")
-def test_group_return_value_is_exit_code_when_not_standalone():
+def test_group_return_value_is_exit_code_when_not_standalone() -> None:
     for expected_exit_code in range(10):
 
         @group("cli")
         @pass_context
-        def cli(ctx: RichContext):
+        def cli(ctx: RichContext) -> None:
             ctx.exit(expected_exit_code)
 
         @cli.command("subcommand")
         @pass_context
-        def subcommand(ctx: RichContext):
+        def subcommand(ctx: RichContext) -> None:
             # I should not run
             ctx.exit(0)
 

--- a/tests/test_exit_code.py
+++ b/tests/test_exit_code.py
@@ -23,17 +23,17 @@ def test_command_exit_code_with_context() -> None:
         assert res.exit_code == expected_exit_code
 
 
-def test_group_exit_code_with_context():
+def test_group_exit_code_with_context() -> None:
     for expected_exit_code in range(10):
 
         @group("cli")
         @pass_context
-        def cli(ctx: RichContext):
+        def cli(ctx: RichContext) -> None:
             ctx.exit(expected_exit_code)
 
         @cli.command("subcommand")
         @pass_context
-        def subcommand(ctx: RichContext):
+        def subcommand(ctx: RichContext) -> None:
             ctx.exit(999)
 
         runner = CliRunner()

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,11 +1,12 @@
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Optional, Type, Union
 
 import click
 import pytest
 from click import UsageError
-from conftest import AssertRichFormat, AssertStr, InvokeCli
 from packaging import version
 from rich.console import Console
+
+from tests.conftest import AssertRichFormat, AssertStr, InvokeCli
 
 import rich_click.rich_click as rc
 from rich_click import command, group, pass_context, rich_config, RichContext, RichHelpConfiguration
@@ -202,7 +203,11 @@ click_version = version.parse(metadata.version("click"))
 )
 @pytest.mark.filterwarnings("ignore:^.*click prior to.*$:RuntimeWarning")
 def test_rich_click(
-    cmd: str, args: str, error: Optional[Type[Exception]], rich_config, assert_rich_format: AssertRichFormat
+    cmd: str,
+    args: str,
+    error: Optional[Type[Exception]],
+    rich_config: Optional[Callable[[Any], Union[RichGroup, RichCommand]]],
+    assert_rich_format: AssertRichFormat,
 ) -> None:
     assert_rich_format(cmd, args, error, rich_config)
 
@@ -350,7 +355,7 @@ def test_rich_config_decorator_order(
     expected_command_type: Type[RichCommand],
     expected_help_output: str,
 ) -> None:
-    @command_callable()
+    @command_callable()  # type: ignore[misc]
     @rich_config(Console(), RichHelpConfiguration(max_width=60, use_markdown=True))
     def cli() -> None:
         """Some help

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -10,6 +10,7 @@ from rich.console import Console
 import rich_click.rich_click as rc
 from rich_click import command, rich_config, RichContext, RichHelpConfiguration
 from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X, CLICK_IS_VERSION_80
+from rich_click.decorators import pass_context
 from rich_click.rich_command import RichCommand
 
 try:
@@ -219,6 +220,7 @@ def test_rich_config_decorator_order(invoke: InvokeCli, assert_str: AssertStr):
         pass
 
     assert hasattr(cli, "__rich_context_settings__") is False
+    assert isinstance(cli, RichCommand)
     assert cli.console is not None
     assert cli.__doc__ is not None
     assert_str(
@@ -281,7 +283,7 @@ def test_rich_config_context_settings(invoke: InvokeCli):
     @click.command(
         cls=RichCommand, context_settings={"rich_console": Console(), "rich_help_config": RichHelpConfiguration()}
     )
-    @click.pass_context
+    @pass_context
     def cli(ctx: RichContext):
         assert isinstance(ctx, RichContext)
         assert ctx.console is not None


### PR DESCRIPTION
WOW. This was a lot of work. I am exhausted.

Long story short: I wanted to get the typing in `rich-click` to work with minimal hacking. I'm not 100% done (I think I may want this working in strict mode). But in the process, I ended up uncovering a lot of weird little issues:

- The typing never actually worked and mypy wasn't really working to its full potential. The reason why is due to the pre-commit config, which used `language: python` and had no third party dependencies. I swap over to `language: system` in the pre-commit and now everything is being actually tested for real.
- The full `@command`, `@command()`, `@command("name")` etc. API was not being supported. See the test cases now for `test_rich_config_decorator_order`-- I have added every single way I can think of to turn a callbacks into a RichCommand (or subclass thereof, i.e. RichGroup). Some things I uncovered here:
    - One big problem here was that the context stuff was being resolved in the `rich_click.command` and `rich_click.group` decorators. **This meant something like `click.Group(...).command(cls=RichCommand)` did not actually use the rich context correctly!** That realization is what motivated adding all those `pytest.param()`s i.e. ways of turning callbacks into RichCommands.
       - The solution to this was to move parsing the context settings to the `__init__` for `RichCommand`.
       - Oh, and when messing around with _that_, I discovered the decorator wasn't working properly. It was extracting `help_config` _even though_ the key that was being set elsewhere was `rich_help_config`. 😬
    - Also, I don't actually think this test case ever worked to begin with? We end up asserting a non-markdown `--help` output!
- We want to override typing for `pass_context` because otherwise the type annotation `ctx: RichContext` does not work in a function signature, due to the fact that the typing is contravariant. I opened an issue in actual click about it here: https://github.com/pallets/click/issues/2623 But my conclusion is they should not fix it / they should mark as "won't do" or something. I think it is better for us to just fix it on our end.
    - Also, it turns out that in the case of `from click import *`, the type annotations are not properly overridden according to mypy! I am not sure what that is about. I manually imported everything in click (notwithstanding anything being deprecated), and add added a `__getattr__` to future proof.
        - **The `__init__.py` will require more work. It is not done!** I need to revisit this and it's one of the bigger reasons why this PR is a "draft."
- I learned that Click 9.0 is actually deprecating the `MultiCommand` and `BaseCommand` classes. 😬 So that recent addition is getting slightly rolled back.

I'm definitely missing some notes. So many changes in this one! I am going to need to sit on this. Also, I don't expect as I submit this for the Click 7.x tests to pass; haven't gotten to that yet. But Click 8.x tests do pass.