### PR TITLE
fix errors in rc cli tool

### DIFF
--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -6,7 +6,7 @@ The intention is to provide attractive help output from click, formatted with ri
 customisation required.
 """
 
-__version__ = "1.7.0dev"
+__version__ = "1.7.0"
 
 # Import the entire click API here.
 # We need to manually import these instead of `from click import *` to force mypy to recognize a few type annotation overrides for the rich_click decorators.


### PR DESCRIPTION
In 1.7.0dev0, I ended up introducing some bugs in the `rich-click` CLI tool. The issue was by patching the `click` module, some things like `isinstance(obj, click.MultiCommand)` checks don't work.

The trick is instead of doing`import click` and using `click.MultiCommand`, instead do `from click import MultiCommand` and use `MultiCommand`. This keeps that object from being patched with the `rich-click` CLI.