### PR TITLE
two fixes

### DIFF
--- a/src/rich_click/decorators.py
+++ b/src/rich_click/decorators.py
@@ -184,7 +184,10 @@ def rich_config(
         if isinstance(obj, (RichCommand, RichGroup)):
             obj.context_settings.update(extra)
         elif callable(obj) and not isinstance(obj, (Command, Group)):
-            setattr(obj, "__rich_context_settings__", extra)
+            if hasattr(obj, "__rich_context_settings__"):
+                obj.__rich_context_settings__.update(extra)
+            else:
+                setattr(obj, "__rich_context_settings__", extra)
         else:
             raise NotSupportedError("`rich_config` requires a `RichCommand` or `RichGroup`. Try using the cls keyword")
         return obj


### PR DESCRIPTION
Two changes right before the 1.7 release:

1. `__rich_context_settings__` is not fully overridden by `rich_config()`. I figure it should be possible for a user to define command-specific settings without overriding an existing `rich_console` should one exist. We were already doing that in the case of a `RichCommand` object, but this should also be true for callbacks.
2. `RichGroup.group` did not work properly for Click 7 because it does not take advantage of the `group_class` variable prior to Click 8. Slight oversight. 😅