### PR TITLE
document rich_config decorator + minor change to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Note that most normal click options should still work, such as `show_default=Tru
 
 > Note: All images below are auto-generated using another side-project of mine: [rich-codex](https://github.com/ewels/rich-codex). Pretty cool!
 
-### Using rich markup
+### Using Rich markup
 
 In order to be as widely compatible as possible with a simple import, rich-click does _not_ parse rich formatting markup (eg. `[red]`) by default. You need to opt-in to this behaviour.
 
@@ -177,6 +177,15 @@ To use rich markup in your help texts, add the following:
 
 ```python
 click.rich_click.USE_RICH_MARKUP = True
+```
+
+Or alternatively, with the `rich_config` and `RichHelpConfiguration`:
+
+```python
+@click.command()
+@click.rich_config(help_config=click.RichHelpConfiguration(use_rich_markup=True))
+def cli():
+    ...
 ```
 
 Remember that you'll need to escape any regular square brackets using a back slash in your help texts,
@@ -195,6 +204,15 @@ You must choose either Markdown or rich markup. If you specify both, Markdown ta
 click.rich_click.USE_MARKDOWN = True
 ```
 
+Or alternatively, with the `RichHelpConfiguration`:
+
+```python
+@click.command()
+@click.rich_config(help_config=click.RichHelpConfiguration(use_markdown=True))
+def cli():
+    ...
+```
+
 ![`python examples/05_markdown.py --help`](docs/images/markdown.svg "Markdown example")
 
 > See [`examples/05_markdown.py`](examples/05_markdown.py) for an example.
@@ -210,6 +228,20 @@ By default, they will get their own panel but you can tell rich-click to bundle 
 ```python
 click.rich_click.SHOW_ARGUMENTS = True
 click.rich_click.GROUP_ARGUMENTS_OPTIONS = True
+```
+
+Or alternatively, with the `RichHelpConfiguration`:
+
+```python
+help_config = click.RichHelpConfiguration(
+    show_arguments=True,
+    group_arguments_options=True
+)
+
+@click.command()
+@click.rich_config(help_config=help_config)
+def cli():
+    ...
 ```
 
 ![`python examples/06_arguments.py --help`](docs/images/arguments.svg "Positional arguments example")
@@ -233,6 +265,18 @@ For this, use the following:
 ```python
 click.rich_click.SHOW_METAVARS_COLUMN = False
 click.rich_click.APPEND_METAVARS_HELP = True
+```
+
+```python
+help_config = click.RichHelpConfiguration(
+    show_metavars_column=False,
+    append_metavars_help=True
+)
+
+@click.command()
+@click.rich_config(help_config=help_config)
+def cli():
+    ...
 ```
 
 ![`python examples/08_metavars.py --help`](docs/images/metavars_appended.svg "Appended metavar")
@@ -498,6 +542,8 @@ USE_CLICK_SHORT_HELP = False  # Use click's default function to truncate help te
 ```
 
 Full type annotations of these config options are availble in `src/rich_click/rich_click.py`.
+
+100% of these options are supported in the `RichHelpConfiguration` class, as well.
 
 ## Contributing
 

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -1,7 +1,5 @@
 import inspect
-import os
 import re
-from os import getenv
 from typing import Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import click
@@ -26,9 +24,13 @@ from rich.text import Text
 from typing_extensions import Literal
 
 from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X, CLICK_IS_BEFORE_VERSION_9X, CLICK_IS_VERSION_80
-from rich_click.rich_help_configuration import OptionHighlighter, RichHelpConfiguration
+from rich_click.rich_help_configuration import (
+    force_terminal_default,
+    OptionHighlighter,
+    RichHelpConfiguration,
+    terminal_width_default,
+)
 from rich_click.rich_help_formatter import RichHelpFormatter
-from rich_click.utils import truthy
 
 # Support rich <= 10.6.0
 try:
@@ -41,14 +43,6 @@ if CLICK_IS_BEFORE_VERSION_9X:
     from click import MultiCommand
 else:
     MultiCommand = Group  # type: ignore[misc,assignment]
-
-
-def _force_terminal() -> Optional[bool]:
-    env_vars = {"GITHUB_ACTIONS", "FORCE_COLOR", "PY_COLORS"}
-    if all(i not in os.environ for i in env_vars):
-        return None
-    else:
-        return any(truthy(getenv(i)) for i in env_vars)
 
 
 # Default styles
@@ -94,14 +88,12 @@ STYLE_ERRORS_PANEL_BORDER: rich.style.StyleType = "red"
 ALIGN_ERRORS_PANEL: rich.align.AlignMethod = "left"
 STYLE_ERRORS_SUGGESTION: rich.style.StyleType = "dim"
 STYLE_ABORTED: rich.style.StyleType = "red"
-WIDTH: Optional[int] = int(getenv("TERMINAL_WIDTH")) if getenv("TERMINAL_WIDTH") else None  # type: ignore[arg-type]
-MAX_WIDTH: Optional[int] = (
-    int(getenv("TERMINAL_WIDTH")) if getenv("TERMINAL_WIDTH") else WIDTH  # type: ignore[arg-type]
-)
+WIDTH: Optional[int] = terminal_width_default()
+MAX_WIDTH: Optional[int] = terminal_width_default()
 COLOR_SYSTEM: Optional[
     Literal["auto", "standard", "256", "truecolor", "windows"]
 ] = "auto"  # Set to None to disable colors
-FORCE_TERMINAL: Optional[bool] = _force_terminal()
+FORCE_TERMINAL: Optional[bool] = force_terminal_default()
 
 # Fixed strings
 HEADER_TEXT: Optional[str] = None


### PR DESCRIPTION
We were not documenting the very excellent `@rich_config()` decorator. I've added that here! I did not go overboard, however; just a couple examples.

I also reorganized the environment variable defaults a bit: notably, `int()` call is made "safe" and the callables to set these defaults are treated as source of truth for how they are set, rather than repeating the logic across a few places.

---

cc @ewels:

Relatedly, I'm a little worried about these env vars... I am wondering if these names should be deprecated and moved to something with `RICH_CLICK_*` prefixes in a future release. Another issue is the env vars being eagerly loaded into the global state (this is what motivated me to try-except the int() call, actually). For most users this will not matter as most users are not mutating environment variables between importing rich click and running their CLI. Still, it doesn't feel ideal.

I will likely open an issue about all of this later for more discussion. TLDR: I think in 1.8 we should introduce deprecation warnings that in 2.x all env var support will move to the `RICH_CLICK_*` namespace (I also wonder if, at that point, you could even make it so every 'simple' config option can be set via an environment variable 👀). And then when we do that, we should document exactly the resolution of config options: The order should be explicitly stated, e.g.: (1) rich_config (2) environment (3) default. Not sure what the order should be, or even if the user should have control over it (maybe even have a config option called `ignore_environment`!). But this is where my head is regarding the config stuff for future releases.

**But**, all that said, I am far more worried about just documenting every config option first in a comprehensive way. We will want a list of every config option, what it does, and every way to set it (similar to how for example `isort` documents their options: https://pycqa.github.io/isort/docs/configuration/options.html).