### PR TITLE
[Draft] Rewrite `rich-click` CLI with a `RichCommand`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = [
     "venv",
     "build",
     "sdist",
-    "tests/**",
+    "tests/fixtures/**",
     "examples/**",
 ]
 ignore = [

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -157,10 +157,6 @@ def main(
     else:
         raise click.ClickException(f"No such script: {script_and_args[0]}")
 
-    if len(args) > 1:
-        if args[0] == "--":
-            del args[0]
-
     prog = module_path.split(".", 1)[0]
 
     sys.argv = [prog, *args]

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -13,7 +13,6 @@ except ImportError:
     import importlib_metadata as metadata  # type: ignore[no-redef,import-not-found,unused-ignore]
 
 import click
-from rich.console import Console
 
 from rich_click.decorators import command as rich_command
 from rich_click.decorators import group as rich_group
@@ -21,9 +20,6 @@ from rich_click.decorators import pass_context, rich_config
 from rich_click.rich_command import RichCommand, RichCommandCollection, RichGroup, RichMultiCommand
 from rich_click.rich_context import RichContext
 from rich_click.rich_help_configuration import RichHelpConfiguration
-
-
-console = Console()
 
 
 def patch(rich_config: Optional[RichHelpConfiguration] = None) -> None:
@@ -79,7 +75,7 @@ class _RichHelpConfigurationParamType(click.ParamType):
                     data = json.loads(value)
                 if not isinstance(data, dict):
                     raise ValueError("--rich-config needs to be a JSON.")
-                return RichHelpConfiguration(**data)
+                return RichHelpConfiguration.load_from_globals(**data)
             except Exception as e:
                 # In normal circumstances, a bad arg to a CLI doesn't
                 # prevent the help text from rendering.

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -1,9 +1,9 @@
 """The command line interface."""
 
 import sys
+from gettext import gettext as _
 from importlib import import_module
-from textwrap import dedent
-from typing import Any, List, Optional
+from typing import List, Optional, Union
 
 
 try:
@@ -14,57 +14,19 @@ except ImportError:
 
 import click
 from rich.console import Console
-from rich.padding import Padding
-from rich.panel import Panel
-from rich.text import Text
 
 from rich_click.decorators import command as rich_command
 from rich_click.decorators import group as rich_group
-from rich_click.rich_click import (
-    ALIGN_ERRORS_PANEL,
-    ERRORS_PANEL_TITLE,
-    STYLE_ERRORS_PANEL_BORDER,
-    STYLE_HELPTEXT,
-    STYLE_HELPTEXT_FIRST_LINE,
-    STYLE_USAGE,
-    STYLE_USAGE_COMMAND,
-)
+from rich_click.decorators import pass_context, rich_config
 from rich_click.rich_command import RichCommand, RichCommandCollection, RichGroup, RichMultiCommand
+from rich_click.rich_context import RichContext
+from rich_click.rich_help_configuration import RichHelpConfiguration
 
 
 console = Console()
 
 
-def _print_usage() -> None:
-    console.print(
-        Padding(
-            Text.from_markup(f"[{STYLE_USAGE}]Usage:[/] rich-click [SCRIPT | MODULE:FUNCTION] [-- SCRIPT_ARGS...]"),
-            1,
-        ),
-        style=STYLE_USAGE_COMMAND,
-    )
-
-
-def _print_help() -> None:
-    help_paragraphs = dedent(main.__doc__ or "").split("\n\n")
-    help_paragraphs = [x.replace("\n", " ").strip() for x in help_paragraphs]
-    console.print(
-        Padding(
-            Text.from_markup(help_paragraphs[0].strip()),
-            (0, 1),
-        ),
-        style=STYLE_HELPTEXT_FIRST_LINE,
-    )
-    console.print(
-        Padding(
-            Text.from_markup("\n\n".join(help_paragraphs[1:]).strip()),
-            (0, 1),
-        ),
-        style=STYLE_HELPTEXT,
-    )
-
-
-def patch() -> None:
+def patch(rich_config: Optional[RichHelpConfiguration] = None) -> None:
     """Patch Click internals to use Rich-Click types."""
     click.group = rich_group
     click.command = rich_command
@@ -73,6 +35,8 @@ def patch() -> None:
     click.CommandCollection = RichCommandCollection  # type: ignore[misc]
     if "MultiCommand" in dir(click):
         click.MultiCommand = RichMultiCommand  # type: ignore[assignment,misc,unused-ignore]
+    if rich_config is not None:
+        rich_config._dump_into_globals()
 
 
 def entry_points(*, group: str) -> "metadata.EntryPoints":  # type: ignore[name-defined]
@@ -88,7 +52,78 @@ def entry_points(*, group: str) -> "metadata.EntryPoints":  # type: ignore[name-
     return epg.get(group, [])
 
 
-def main(args: Optional[List[str]] = None) -> Any:
+class _RichHelpConfigurationParamType(click.ParamType):
+
+    name = "JSON"
+
+    def __repr__(self) -> str:
+        return "JSON"
+
+    def convert(
+        self,
+        value: Optional[Union[RichHelpConfiguration, str]],
+        param: Optional[click.Parameter],
+        ctx: Optional[click.Context],
+    ) -> Optional[RichHelpConfiguration]:
+
+        if value is None or isinstance(value, RichHelpConfiguration):
+            return value
+        else:
+            try:
+                import json
+
+                if value.startswith("@"):
+                    with open(value[1:], "r") as f:
+                        data = json.load(f)
+                else:
+                    data = json.loads(value)
+                if not isinstance(data, dict):
+                    raise ValueError("--rich-config needs to be a JSON.")
+                return RichHelpConfiguration(**data)
+            except Exception as e:
+                # In normal circumstances, a bad arg to a CLI doesn't
+                # prevent the help text from rendering.
+                if ctx is not None and ctx.params.get("show_help", False):
+                    click.echo(ctx.get_help(), color=ctx.color)
+                    ctx.exit()
+                else:
+                    raise e
+
+
+@rich_command("rich-click", context_settings=dict(allow_interspersed_args=False, help_option_names=[]))
+@click.argument("script_and_args", nargs=-1, metavar="[SCRIPT | MODULE:CLICK_COMMAND] [-- SCRIPT_ARGS...]")
+@click.option(
+    "--rich-config",
+    type=_RichHelpConfigurationParamType(),
+    help="Keyword arguments to pass into the [de]RichHelpConfiguration()[/] used"
+    " to render the help text of the command. You can pass either a JSON directly, or a file"
+    " prefixed with `@` (for example: '@rich_config.json'). Note that the --rich-config"
+    " option is also used to render this help text you're reading right now!",
+)
+@click.option(
+    # The rich-click CLI uses a special implementation of --help,
+    # which is aware of the --rich-config object.
+    "--help",
+    "-h",
+    "show_help",
+    is_eager=True,
+    is_flag=True,
+    help=_("Show this message and exit."),
+)
+@pass_context
+@rich_config(
+    help_config={
+        "use_markdown": False,
+        "use_rich_markup": True,
+        "errors_epilogue": "[d]Please run [yellow bold]rich-click --help[/] for usage information.[/]",
+    }
+)
+def main(
+    ctx: RichContext,
+    script_and_args: List[str],
+    rich_config: Optional[RichHelpConfiguration],
+    show_help: bool,
+) -> None:
     """
     The [link=https://github.com/ewels/rich-click]rich-click[/] CLI provides attractive help output from any
     tool using [link=https://click.palletsprojects.com/]click[/], formatted with
@@ -97,60 +132,46 @@ def main(args: Optional[List[str]] = None) -> Any:
     The rich-click command line tool can be prepended before any Python package
     using native click to provide attractive richified click help output.
 
-    For example, if you have a package called [blue]my_package[/] that uses click,
+    For example, if you have a package called [argument]my_package[/] that uses click,
     you can run:
 
-    [blue]  rich-click my_package --help  [/]
+    >>> [command]rich-click[/] [argument]my_package[/] [option]--help[/]
 
-    It only works if the package is using vanilla click without customised [cyan]group()[/]
-    or [cyan]command()[/] classes.
+    This does not always work if the package is using customised [b]click.group()[/]
+    or [b]click.command()[/] classes.
     If in doubt, please suggest to the authors that they use rich_click within their
     tool natively - this will always give a better experience.
     """  # noqa: D400, D401
-    args = args or sys.argv[1:]
-    if not args or args == ["--help"]:
-        # Print usage if we got no args, or only --help
-        _print_usage()
-        _print_help()
-        sys.exit(0)
-    else:
-        script_name = args[0]
+    if (show_help or not script_and_args) and not ctx.resilient_parsing:
+        if rich_config is not None:
+            rich_config.use_markdown = False
+            rich_config.use_rich_markup = True
+            ctx.help_config = rich_config
+        click.echo(ctx.get_help(), color=ctx.color)
+        ctx.exit()
+
+    script, *args = script_and_args
+
     scripts = {script.name: script for script in entry_points(group="console_scripts")}
-    if script_name in scripts:
-        # a valid script was passed
-        script = scripts[script_name]
-        module_path, function_name = script.value.split(":", 1)
-        prog = script_name
-    elif ":" in script_name:
+    if script in scripts:
+        module_path, function_name = scripts[script].value.split(":", 1)
+    elif ":" in script:
         # the path to a function was passed
-        module_path, function_name = args[0].split(":", 1)
-        prog = module_path.split(".", 1)[0]
+        module_path, function_name = script.split(":", 1)
     else:
-        _print_usage()
-        console.print(
-            Panel(
-                Text.from_markup(f"No such script: [bold]{script_name}[/]"),
-                border_style=STYLE_ERRORS_PANEL_BORDER,
-                title=ERRORS_PANEL_TITLE,
-                title_align=ALIGN_ERRORS_PANEL,
-            )
-        )
-        console.print(
-            Padding(
-                "Please run [yellow bold]rich-click --help[/] for usage information.",
-                (0, 1),
-            ),
-            style="dim",
-        )
-        sys.exit(1)
+        raise click.ClickException(f"No such script: {script_and_args[0]}")
+
     if len(args) > 1:
-        if args[1] == "--":
-            del args[1]
-    sys.argv = [prog, *args[1:]]
+        if args[0] == "--":
+            del args[0]
+
+    prog = module_path.split(".", 1)[0]
+
+    sys.argv = [prog, *args]
     # patch click before importing the program function
-    patch()
+    patch(rich_config=rich_config)
     # import the program function
     module = import_module(module_path)
     function = getattr(module, function_name)
     # simply run it: it should be patched as well
-    return function()
+    function()

--- a/src/rich_click/rich_help_configuration.py
+++ b/src/rich_click/rich_help_configuration.py
@@ -205,6 +205,16 @@ class RichHelpConfiguration:
         inst = cls(**kw)
         return inst
 
+    def _dump_into_globals(self, module: Optional[ModuleType] = None) -> None:
+        if module is None:
+            import rich_click.rich_click as rc
+
+            module = rc
+        for k, v in self.__dataclass_fields__.items():
+            if v.init:
+                if hasattr(module, k.upper()):
+                    setattr(module, k.upper(), getattr(self, k))
+
 
 def __getattr__(name: str) -> Any:
     if name == "OptionHighlighter":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# ruff: noqa: D104

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# flake8: noqa D*
+# ruff: noqa: D101,D103,D401
 import importlib
 import json
 import os
@@ -7,16 +7,15 @@ from dataclasses import asdict
 from importlib import reload
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, cast, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union, cast
 
 import click
 import pytest
-from click.testing import CliRunner, Result
-from typing_extensions import Protocol
-
 import rich_click.rich_click as rc
+from click.testing import CliRunner, Result
 from rich_click.rich_command import RichCommand, RichGroup
 from rich_click.rich_help_configuration import RichHelpConfiguration
+from typing_extensions import Protocol
 
 
 @pytest.fixture
@@ -42,7 +41,7 @@ def click_major_version() -> int:
 class AssertStr(Protocol):
     def __call__(self, actual: str, expectation: Union[str, Path]) -> None:
         """
-        Assert strings by normalizining line endings
+        Assert strings by normalizining line endings.
 
         Args:
         ----
@@ -138,10 +137,6 @@ class InvokeCli(Protocol):
 
         Small convenience fixture to allow invoking a click Command
         without standalone mode.
-
-        Args:
-        ----
-            cmd: Click Command
         """
         ...
 
@@ -160,7 +155,7 @@ class AssertRichFormat(Protocol):
         rich_config: Optional[Callable[[Any], Union[RichGroup, RichCommand]]],
     ) -> None:
         """
-        Invokes the cli command and applies assertions against the results
+        Invokes the cli command and applies assertions against the results.
 
         This command resolves the cli application from the fixtures directory dynamically
         to isolate module configuration state between tests. It will also assert that

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,13 @@
+# ruff: noqa: D101,D103,D401
+import json
+from dataclasses import asdict
 from typing import TYPE_CHECKING
 
 import pytest
-
-from rich_click import group, command, rich_config, RichHelpConfiguration, RichContext
-from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
 import rich_click.rich_click as rc
-from dataclasses import asdict
-import json
+from rich_click import RichContext, RichHelpConfiguration, command, group, rich_config
+from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
+
 
 if CLICK_IS_BEFORE_VERSION_8X:
     pytest.skip(reason="rich_config not supported for click < 8.", allow_module_level=True)

--- a/tests/test_exit_code.py
+++ b/tests/test_exit_code.py
@@ -1,11 +1,12 @@
+# ruff: noqa: D101,D103,D401
 import sys
 
 import click
 import pytest
 from click.testing import CliRunner
-
-from rich_click import command, group, pass_context, RichContext
+from rich_click import RichContext, command, group, pass_context
 from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
+
 
 # Don't use the 'invoke' fixture because we want control over the standalone_mode kwarg.
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,18 +1,19 @@
+# ruff: noqa: D101,D103,D401
 from typing import Any, Callable, Optional, Type, Union
 
 import click
 import pytest
+import rich_click.rich_click as rc
 from click import UsageError
+from click.testing import CliRunner
 from packaging import version
 from rich.console import Console
-from click.testing import CliRunner
-
-from tests.conftest import AssertRichFormat, AssertStr, InvokeCli
-
-import rich_click.rich_click as rc
-from rich_click import command, group, pass_context, rich_config, RichContext, RichHelpConfiguration
+from rich_click import RichContext, RichHelpConfiguration, command, group, pass_context, rich_config
 from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X, CLICK_IS_VERSION_80
 from rich_click.rich_command import RichCommand, RichGroup
+
+from tests.conftest import AssertRichFormat, AssertStr
+
 
 try:
     from importlib import metadata  # type: ignore[import,unused-ignore]
@@ -230,7 +231,7 @@ if rich_version.major == 12:
     command_help_output = """
  Usage: cli [OPTIONS]
 
- Some help
+ Some help.
  ╔════════════════════════════════════════════════════════╗
  ║                         Header                         ║
  ╚════════════════════════════════════════════════════════╝
@@ -242,7 +243,7 @@ if rich_version.major == 12:
     group_help_output = """
  Usage: cli [OPTIONS] COMMAND [ARGS]...
 
- Some help
+ Some help.
  ╔════════════════════════════════════════════════════════╗
  ║                         Header                         ║
  ╚════════════════════════════════════════════════════════╝
@@ -255,7 +256,7 @@ else:
     command_help_output = """
  Usage: cli [OPTIONS]
 
- Some help
+ Some help.
  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃                         Header                         ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -267,7 +268,7 @@ else:
     group_help_output = """
  Usage: cli [OPTIONS] COMMAND [ARGS]...
 
- Some help
+ Some help.
  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃                         Header                         ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -370,7 +371,7 @@ def test_rich_config_decorator_order(
     )
     def cli() -> None:
         """
-        Some help
+        Some help.
 
         # Header
         """
@@ -383,7 +384,7 @@ def test_rich_config_decorator_order(
     assert_str(
         cli.__doc__,
         """
-    Some help
+    Some help.
 
     # Header
     """,
@@ -403,7 +404,7 @@ def test_rich_config_max_width(cli_runner: CliRunner, assert_str: AssertStr) -> 
 
     @command()
     def cli() -> None:
-        """Some help text"""
+        """Some help text."""
         pass
 
     result = cli_runner.invoke(cli, "--help")
@@ -413,7 +414,7 @@ def test_rich_config_max_width(cli_runner: CliRunner, assert_str: AssertStr) -> 
         """
 Usage: cli [OPTIONS]
 
- Some help text
+ Some help text.
 
 ╭─ Options ────────────────────────────────────────────────────╮
 │ --help      Show this message and exit.                      │

--- a/tests/test_rich_click_cli.py
+++ b/tests/test_rich_click_cli.py
@@ -1,0 +1,78 @@
+# ruff: noqa: D101,D103,D401
+import sys
+from inspect import cleandoc
+from pathlib import Path
+
+import pytest
+import rich_click.rich_click as rc
+from click.testing import CliRunner
+from pytest import MonkeyPatch
+from rich_click.cli import main
+from rich_click.rich_context import RichContext
+
+from tests.conftest import AssertStr
+
+
+@pytest.fixture(autouse=True)
+def default_config(initialize_rich_click: None) -> None:
+    # Default config settings from https://github.com/Textualize/rich/blob/master/tests/render.py
+    rc.WIDTH = 100
+    rc.COLOR_SYSTEM = None
+    rc.FORCE_TERMINAL = True
+
+
+@pytest.fixture
+def simple_script(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    path = tmp_path / "scripts"
+    path.mkdir()
+    f = cleandoc(
+        '''
+        import click
+
+        @click.command
+        def cli():
+            """My help text"""
+            ...
+
+        cli()
+        '''
+    )
+    py_script = path / "mymodule.py"
+    py_script.write_text(f)
+
+    monkeypatch.setattr(sys, "path", [path.as_posix(), *sys.path.copy()])
+    monkeypatch.setattr(RichContext, "command_path", "mymodule")
+
+    return
+
+
+def test_simple_rich_click_cli(simple_script: None, cli_runner: CliRunner, assert_str: AssertStr) -> None:
+    res = cli_runner.invoke(main, ["mymodule:cli", "--help"])
+
+    expected_output = """
+ Usage: mymodule [OPTIONS]
+
+ My help text
+
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+
+    assert_str(actual=res.stdout, expectation=expected_output)
+
+
+def test_custom_config_rich_click_cli(simple_script: None, cli_runner: CliRunner, assert_str: AssertStr) -> None:
+    res = cli_runner.invoke(main, ["--rich-config", '{"options_panel_title": "Custom Name"}', "mymodule:cli", "--help"])
+
+    expected_output = """
+ Usage: mymodule [OPTIONS]
+
+ My help text
+
+╭─ Custom Name ────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+
+    assert_str(actual=res.stdout, expectation=expected_output)


### PR DESCRIPTION
Resolves #155 and adds a new feature to the `rich-click` CLI: `--rich-config [JSON]`, which allows the user to set a config for a command they're wrapping with `rich-click`. Note that `--rich-config` should also work not just for normal click commands but also rich-click commands.

This is a work in progress, and needs a lot of testing.