### PR TITLE
Pixel font only on top-level headings

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -44,8 +44,7 @@ a.internal-link::after {
 }
 
 .md-header__topic, .md-header__topic code,
-h1, h1 code, h2, h2 code, h3, h3 code,
-h4, h4 code, h5, h5 code,
+h1, h1 code,
 .md-header__header, .md-header__header code {
   font-family: "pixelmix";
 }


### PR DESCRIPTION
The Pixel font is fun but I find it a little difficult to read, in the docs I find it gets in the way a bit on the headings further into the page.

In this PR I drop it to just the top-level headings, which is typically just the page titles. Hopefully this is still fun but also a bit more accessible.

Happy to discuss, just figured I'd put in a PR as I was playing locally anyway.