### PR TITLE
Add note about MacPorts installation to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,8 +94,8 @@ Click, formatted with Rich, with minimal customisation required.
     sudo port install py-rich-click
     ```
 
-    !!! danger "Depreciated"
-        This installation method is deprecated.
+    !!! note "Depreciated"
+        This installation method is not officially supported, and is not guaranteed to be up to date.
 
 ## Examples
 


### PR DESCRIPTION
resolves #171. tldr, it is uncommon to suggest using an installation method that is not officially supported (i.e. one where we do not have control over releases). It is preferable then that we clarify that this method is not officially supported.