### PR TITLE
Fix example 04

### DIFF
--- a/examples/04_rich_markup.py
+++ b/examples/04_rich_markup.py
@@ -8,7 +8,7 @@ click.rich_click.USE_RICH_MARKUP = True
 @click.option(
     "--input",
     type=click.Path(),
-    help="Input [magenta bold]file[/]. [dim]\[default: a custom default][/]",
+    help="Input [magenta bold]file[/]. [dim][default: a custom default][/]",
 )
 @click.option(
     "--type",


### PR DESCRIPTION
Fix the warning that's showing up in the docs example:

![rich_markup](https://github.com/user-attachments/assets/5f70c759-e220-4f24-9e12-d1803e300a37)
