### PR TITLE
fix: escape square brackets in help text for rich markup

### DIFF
--- a/examples/04_rich_markup.py
+++ b/examples/04_rich_markup.py
@@ -8,7 +8,7 @@ click.rich_click.USE_RICH_MARKUP = True
 @click.option(
     "--input",
     type=click.Path(),
-    help="Input [magenta bold]file[/]. [dim][default: a custom default][/]",
+    help=r"Input [magenta bold]file[/]. [dim]\[default: a custom default][/]",
 )
 @click.option(
     "--type",


### PR DESCRIPTION
#208 fixed the warning message, but also removed the text in the square brackets 🙈 

This fix should be better.