### PR TITLE
fix/exception-in-console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.8.5 (2024-12-01)
+
+- Fix issue with error messages not using user-defined styles. [[#215](https://github.com/ewels/rich-click/pull/215)] ([@sankarngrjn](https://github.com/sankarngrjn))
+
 ## Version 1.8.4 (2024-11-12)
 
 - Support `rich.text.Text()` objects for `header_text`, `footer_text`, `errors_suggestion`, and `errors_epilogue`.

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -6,7 +6,7 @@ The intention is to provide attractive help output from Click, formatted with Ri
 customisation required.
 """
 
-__version__ = "1.8.4"
+__version__ = "1.8.5"
 
 # Import the entire click API here.
 # We need to manually import these instead of `from click import *` to force

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -167,10 +167,10 @@ class RichCommand(click.Command):
                 if not standalone_mode:
                     raise
                 if ctx is not None:
-                    config = ctx.help_config
+                    formatter = ctx.make_formatter()
                 else:
                     config = self._generate_rich_help_config()
-                formatter = self.context_class.formatter_class(config=config, file=sys.stderr)
+                    formatter = self.context_class.formatter_class(console=self.console, config=config, file=sys.stderr)
                 from rich_click.rich_help_rendering import rich_format_error
 
                 rich_format_error(e, formatter)
@@ -192,10 +192,10 @@ class RichCommand(click.Command):
                 raise
             try:
                 if ctx is not None:
-                    config = ctx.help_config
+                    formatter = ctx.make_formatter()
                 else:
                     config = self._generate_rich_help_config()
-                formatter = self.context_class.formatter_class(config=config)
+                    formatter = self.context_class.formatter_class(console=self.console, config=config)
             except Exception:
                 click.echo("Aborted!", file=sys.stderr)
             else:


### PR DESCRIPTION
Previously, when passing rich_console in context_settings, all outputs except exceptions were rendered under the provided console. This caused inconsistencies in the output format, as exceptions would bypass the rich console, leading to a mismatch in styling or behavior.

This change ensures that exceptions are also captured and displayed within the provided rich_console. By addressing this, all outputs, including exceptions, will now conform to the same console formatting, maintaining consistency across the board.

Ref. Past
<img width="598" alt="1" src="https://github.com/user-attachments/assets/c194d2ed-ce88-4d9b-bf9e-9f4c6122c88c">
<img width="1204" alt="2" src="https://github.com/user-attachments/assets/c928b8c1-a0fb-4813-9cd3-fa17baca7802">

Ref. Present
<img width="700" alt="3" src="https://github.com/user-attachments/assets/c46b618a-7a58-4928-b92d-ffa09d635e8c">
