### PR TITLE
[Draft] Enhance documentation with accessibility and comparison pages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,11 @@ repos:
         types: [python]
         exclude: ^examples|^docs/
         require_serial: true
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+    - id: codespell
+      files: ^docs/.*\.md$
+      additional_dependencies:
+        - tomli

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - Rich is a _"Python library for rich text and beautiful formatting in the terminal"_.
 
 The intention of `rich-click` is to provide attractive help output from
-Click, formatted with Rich, with minimal customisation required.
+Click, formatted with Rich, with minimal customization required.
 
 ## Features
 
@@ -39,7 +39,7 @@ Click, formatted with Rich, with minimal customisation required.
 - 🎁 Group commands and options into named panels
 - ❌ Well formatted error messages
 - 🔢 Easily give custom sort order for options and commands
-- 🎨 Extensive customisation of styling and behaviour possible
+- 🎨 Extensive customization of styling and behaviour possible
 
 ## Installation
 

--- a/docs/blog/posts/pycon-sweden-2024.md
+++ b/docs/blog/posts/pycon-sweden-2024.md
@@ -21,7 +21,7 @@ You can find my slides below:
 ## Slides
 
 
-[Open in new tab &nbsp; :octicons-link-external-16:](/rich-click/images/blog/pycon-sweden-2024/Ewels-PyCon-Sweden-2024.pdf){ .md-button }
+[Open in new tab &nbsp; :octicons-link-external-16:](../../images/blog/pycon-sweden-2024/Ewels-PyCon-Sweden-2024.pdf){ .md-button }
 
 
 <iframe style="width: 100%; border: 1px solid #333; aspect-ratio: 16 / 10;" src="/rich-click/images/blog/pycon-sweden-2024/Ewels-PyCon-Sweden-2024.pdf" title="PyCon Sweden 2024 Slides - Phil Ewels"></iframe>

--- a/docs/code_snippets/accessibility/colors.py
+++ b/docs/code_snippets/accessibility/colors.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.box import SIMPLE
 from rich.table import Table
 
-console = Console()
+console = Console(color_system="truecolor")
 table = Table(title="ANSI Colors", box=SIMPLE)
 colors = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
 table.add_column("Color", style="bold")

--- a/docs/code_snippets/accessibility/colors.py
+++ b/docs/code_snippets/accessibility/colors.py
@@ -1,0 +1,26 @@
+# /// script
+# dependencies = [
+#   "rich",
+# ]
+from rich.console import Console
+from rich.box import SIMPLE
+from rich.table import Table
+
+console = Console()
+table = Table(title="ANSI Colors", box=SIMPLE)
+colors = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
+table.add_column("Color", style="bold")
+
+for variant in ["Normal", "Dim", "Bright", "Dim +\nBright"]:
+    table.add_column(variant, style="bold")
+
+for color in colors:
+    table.add_row(
+        color,
+        *[
+            f"[{style}{color}]██████[/{style}{color}]"
+            for style in ["", "dim ", "bright_", "dim bright_"]
+        ]
+    )
+
+console.print(table)

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -123,6 +123,8 @@ terminal_width: 48
 -->
 ![`python colors.py`](../images/code_snippets/accessibility/colors.svg){.screenshot}
 
+(The colors you see when running this locally will differ from the colors in the image.)
+
 The fact that the colors are not deterministic is a _benefit_ for accessibility; it means, for example, a user can customize their terminal so that the ANSI "red" is more suitable for them.
 Nearly every modern terminal allows for this sort of customization.
 

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -118,6 +118,8 @@ Below is a quick script that renders all of these colors:
 
 <!-- RICH-CODEX
 working_dir: docs/code_snippets/accessibility
+hide_command: true
+terminal_width: 48
 -->
 ![`python colors.py`](../images/code_snippets/accessibility/colors.svg){.screenshot}
 

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -7,6 +7,56 @@ Colorblindness impacts roughly 4% of the general population, meaning that if you
 
 Fortunately, there are ways as both developers and users to address these accessibility concerns, as detailed on this page.
 
+## Colorblindness accessibility for users
+
+If you are a user of a **rich-click** CLI, there are a few options you have to improve accessibility for yourself.
+
+### 1. Configure your terminal's 4-bit ANSI colors
+
+The 4-bit ANSI color system is a set of 16 different colors implemented in every terminal. This is the most common way to set colors.
+These colors are **not** deterministic; different terminals use slightly different hex values for the ANSI colors. [Wikipedia has a full breakdown of all the variations in these colors](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit)
+
+Most modern terminals have the ability to customize all of these colors in the terminals' settings.
+If you are having difficulty distinguishing colors, it is recommended that you adjust these settings.
+
+!!! note
+    This will only work for CLIs that utilize the 4-bit ANSI color system.
+    CLIs that utilize hex values or other color systems will not be impacted by your terminal's ANSI color settings.
+
+### 2. Use the `NO_COLOR` environment variable
+
+Rich uses the `NO_COLOR` standard ([more information here](https://no-color.org/)), which means it has a built-in capability that allows the user to suppress color.
+The Rich docs also go over additional and related console settings [here](https://rich.readthedocs.io/en/latest/console.html).
+
+So, instead of running your CLI like this:
+
+```shell
+$ python cli.py
+```
+
+You can instead do the following:
+
+```shell
+# Set environment variable, then run:
+export NO_COLOR=1
+python cli.py
+
+# ... Or run as a single line:
+NO_COLOR=1 python cli.py
+```
+
+And this will disable all colors in **rich-click**.
+
+You can also add `NO_COLOR=1` to your `~/.bashrc` (if using bash) or `~/.zshrc` (if using zsh):
+
+```shell
+# If using bash:
+echo "NO_COLOR=1" > ~/.bashrc
+
+# If using zsh:
+echo "NO_COLOR=1" > ~/.zshrc
+```
+
 ## Colorblindness accessibility considerations for developers
 
 If you would like to make your CLI more accessible for others, there are a few rules of thumb you can follow:
@@ -15,9 +65,9 @@ If you would like to make your CLI more accessible for others, there are a few r
 
 If you are using colors inside your print statements and interactive elements, you can make your CLI more accessible with the following:
 
-- Replace `click.echo()` with `rich.print()`
-- Replace `click.confirm()` with `rich.prompt.Confirm.ask()`
-- Replace `click.prompt()` with `rich.prompt.Prompt.ask()`
+- Replace `click.echo()` with `rich.print()` ([Rich docs](https://rich.readthedocs.io/en/stable/introduction.html#quick-start))
+- Replace `click.prompt()` with `rich.prompt.Prompt.ask()` ([Rich docs](https://rich.readthedocs.io/en/stable/prompt.html))
+- Replace `click.confirm()` with `rich.prompt.Confirm.ask()` ([Rich docs](https://rich.readthedocs.io/en/stable/prompt.html))
 
 The reason why the Rich features are more accessible than the corresponding Click features is because of the `NO_COLOR` environment variable, which the Rich library uses to disables all color. This environment variable does not work with `click.style()`, however.
 
@@ -63,36 +113,16 @@ In total, when counting `dim`, this gives developers 32 different colors that ca
 Below is a quick script that renders all of these colors:
 
 ```python
-# /// script
-# dependencies = [
-#   "rich",
-# ]
-from rich.console import Console
-from rich.box import SIMPLE
-from rich.table import Table
-
-console = Console()
-table = Table(title="ANSI Colors", box=SIMPLE)
-colors = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
-table.add_column("Color", style="bold")
-
-for variant in ["Normal", "Dim", "Bright", "Dim +\nBright"]:
-    table.add_column(variant, style="bold")
-
-for color in colors:
-    table.add_row(
-        color,
-        *[
-            f"[{style}{color}]██████[/{style}{color}]"
-            for style in ["", "dim ", "bright_", "dim bright_"]
-        ]
-    )
-
-console.print(table)
+{!code_snippets/accessibility/colors.py!}
 ```
 
+<!-- RICH-CODEX
+working_dir: docs/code_snippets/accessibility
+-->
+![`python colors.py`](../images/code_snippets/accessibility/colors.svg){.screenshot}
+
 The fact that the colors are not deterministic is a _benefit_ for accessibility; it means, for example, a user can customize their terminal so that the ANSI "red" is more suitable for them.
-Nearly every modern terminal allows for this sort of customisation.
+Nearly every modern terminal allows for this sort of customization.
 
 This means that developers looking to create a more accessible experience should prefer ANSI colors.
 
@@ -100,43 +130,3 @@ So, for example:
 
 - `RichHelpConfiguration(style_option="red")` is more accessible because users can configure the hex value of this red.
 - `RichHelpConfiguration(style_option="#FF0000")` is less accessible because it is not configurable by the end user.
-
-## Colorblindness accessibility for users
-
-If you are a user of a **rich-click** CLI, there are a few options you have to improve accessibility for yourself.
-
-### 1. Configure your terminal's 4-bit ANSI colors
-
-The 4-bit ANSI color system is a set of 16 different colors implemented in effectively every terminal, and they are the most common way to set colors.
-These colors are **not** deterministic; different terminals use slightly different hex values for the ANSI colors. [Wikipedia has a full breakdown of all the variations in these colors](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit)
-
-Most modern terminals have the ability to customise all of these colors in the terminals' settings.
-If you are having difficulty distinguishing colors, it is recommended that you adjust these settings.
-
-!!! note
-    This will only work for CLIs that utilize the 4-bit ANSI color system.
-    CLIs that utilize hex values or other color systems will not be impacted by your terminal's ANSI color settings.
-
-### 2. Use the `NO_COLOR` environment variable
-
-Rich uses the `NO_COLOR` standard ([more information here](https://no-color.org/)), which means it has a built-in capability that allows the user to suppress color.
-The Rich docs also go over additional and related console settings [here](https://rich.readthedocs.io/en/latest/console.html).
-
-So, instead of running your CLI like this:
-
-```shell
-$ python cli.py
-```
-
-You can instead do the following:
-
-```shell
-# Set environment variable, then run:
-export NO_COLOR=1
-python cli.py
-
-# ... Or run as a single line:
-NO_COLOR=1 python cli.py
-```
-
-And this will disable all colors in **rich-click**.

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -47,14 +47,14 @@ NO_COLOR=1 python cli.py
 
 And this will disable all colors in **rich-click**.
 
-You can also add `NO_COLOR=1` to your `~/.bashrc` (if using bash) or `~/.zshrc` (if using zsh):
+You can also add `export NO_COLOR=1` to your `~/.bashrc` (if using bash) or `~/.zshrc` (if using zsh) for it to be set automatically every time you open a new terminal shell:
 
 ```shell
 # If using bash:
-echo "NO_COLOR=1" > ~/.bashrc
+echo "export NO_COLOR=1" >> ~/.bashrc
 
 # If using zsh:
-echo "NO_COLOR=1" > ~/.zshrc
+echo "export NO_COLOR=1" >> ~/.zshrc
 ```
 
 ## Colorblindness accessibility considerations for developers

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -7,11 +7,40 @@ Colorblindness impacts roughly 4% of the general population, meaning that if you
 
 Fortunately, there are ways as both developers and users to address these accessibility concerns, as detailed on this page.
 
-## Colorblindness accessibility for users
+## For users
 
 If you are a user of a **rich-click** CLI, there are a few options you have to improve accessibility for yourself.
 
-### 1. Configure your terminal's 4-bit ANSI colors
+### 1. Use the `NO_COLOR` environment variable
+
+Rich uses the `NO_COLOR` standard ([more information here](https://no-color.org/)), giving rich-click built-in capability to allow the user to suppress color.
+
+So, to run any rich-click CLI program without colour, you can do:
+
+```shell
+export NO_COLOR=1  # Set environment variable in shell
+python cli.py      # Run CLI tool
+
+# ... Or run as a single line:
+NO_COLOR=1 python cli.py
+```
+
+In order to set this environment variable automatically every time you use the terminal, you can add it to your `~/.bashrc` (if using bash) or `~/.zshrc` (if using zsh):
+
+=== "bash"
+    ```shell
+    echo "export NO_COLOR=1" >> ~/.bashrc
+    ```
+
+=== "zsh"
+    ```shell
+    echo "export NO_COLOR=1" >> ~/.zshrc
+    ```
+
+!!!tip
+    Note that other programs may also respect `NO_COLOR`, so it could have other effects!
+
+### 2. Configure your terminal's 4-bit ANSI colors
 
 The 4-bit ANSI color system is a set of 16 different colors implemented in every terminal. This is the most common way to set colors.
 These colors are **not** deterministic; different terminals use slightly different hex values for the ANSI colors. [Wikipedia has a full breakdown of all the variations in these colors](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit)
@@ -23,62 +52,20 @@ If you are having difficulty distinguishing colors, it is recommended that you a
     This will only work for CLIs that utilize the 4-bit ANSI color system.
     CLIs that utilize hex values or other color systems will not be impacted by your terminal's ANSI color settings.
 
-### 2. Use the `NO_COLOR` environment variable
-
-Rich uses the `NO_COLOR` standard ([more information here](https://no-color.org/)), which means it has a built-in capability that allows the user to suppress color.
-The Rich docs also go over additional and related console settings [here](https://rich.readthedocs.io/en/latest/console.html).
-
-So, instead of running your CLI like this:
-
-```shell
-$ python cli.py
-```
-
-You can instead do the following:
-
-```shell
-# Set environment variable, then run:
-export NO_COLOR=1
-python cli.py
-
-# ... Or run as a single line:
-NO_COLOR=1 python cli.py
-```
-
-And this will disable all colors in **rich-click**.
-
-You can also add `export NO_COLOR=1` to your `~/.bashrc` (if using bash) or `~/.zshrc` (if using zsh) for it to be set automatically every time you open a new terminal shell:
-
-```shell
-# If using bash:
-echo "export NO_COLOR=1" >> ~/.bashrc
-
-# If using zsh:
-echo "export NO_COLOR=1" >> ~/.zshrc
-```
-
-## Colorblindness accessibility considerations for developers
+## For developers
 
 If you would like to make your CLI more accessible for others, there are a few rules of thumb you can follow:
 
 ### 1. Use Rich features over Click features
 
-If you are using colors inside your print statements and interactive elements, you can make your CLI more accessible with the following:
+There are some Click features that rich-click doesn't override such as print statements and interactive prompts (see [Comparison of Click and rich-click](comparison_of_click_and_rich_click.md#click-features-that-rich-click-does-not-override)).
 
-- Replace `click.echo()` with `rich.print()` ([Rich docs](https://rich.readthedocs.io/en/stable/introduction.html#quick-start))
-- Replace `click.prompt()` with `rich.prompt.Prompt.ask()` ([Rich docs](https://rich.readthedocs.io/en/stable/prompt.html))
-- Replace `click.confirm()` with `rich.prompt.Confirm.ask()` ([Rich docs](https://rich.readthedocs.io/en/stable/prompt.html))
-
-The reason why the Rich features are more accessible than the corresponding Click features is because of the `NO_COLOR` environment variable, which the Rich library uses to disables all color. This environment variable does not work with `click.style()`, however.
-
-!!! info
-    `NO_COLOR` is a _de facto_ standard for disabling color across a wide variety of terminal programs and frameworks.
-    You can read more [here](https://no-color.org/) about the standard.
+In these cases, we recommend using native Rich functionality so that your end users can benefit from `NO_COLOR`, which Click does not support.
 
 So, for example:
 
-- `Confirm.ask("[red]Are you sure?[/]")` is more accessible because it works with `NO_COLOR`.
-- `click.confirm(click.echo("Are you sure?", fg="red"))` is less accessible because it cannot be overridden by `NO_COLOR`.
+- `#!python Confirm.ask("[red]Are you sure?[/]")` is more accessible because it works with `NO_COLOR`.
+- `#!python click.confirm(click.echo("Are you sure?", fg="red"))` is less accessible because it cannot be overridden by `NO_COLOR`.
 
 ### 2. Use 4-bit ANSI colors
 
@@ -90,25 +77,16 @@ These colors are **not** deterministic; different terminals use slightly differe
 
 There are 16 total ANSI colors: 8 base ANSI colors, with each one having a "bright" variant:
 
-- `black`
-- `red`
-- `green`
-- `yellow`
-- `blue`
-- `magenta`
-- `cyan`
-- `white`
-- `bright_black`
-- `bright_red`
-- `bright_green`
-- `bright_yellow`
-- `bright_blue`
-- `bright_magenta`
-- `bright_cyan`
-- `bright_white`
+- `black`, `bright_black`
+- `red`, `bright_red`
+- `green`, `bright_green`
+- `yellow`, `bright_yellow`
+- `blue`, `bright_blue`
+- `magenta`, `bright_magenta`
+- `cyan`, `bright_cyan`
+- `white`, `bright_white`
 
-Additionally, each one of these can be modified with `dim`, which in modern terminals just applies a change to the opacity of the color.
-In total, when counting `dim`, this gives developers 32 different colors that can be shown.
+Additionally, each one of these can be modified with `dim`, which in modern terminals just applies a change to the opacity of the color, giving developers a total of 32 different colors that can be shown.
 
 Below is a quick script that renders all of these colors:
 
@@ -132,5 +110,5 @@ This means that developers looking to create a more accessible experience should
 
 So, for example:
 
-- `RichHelpConfiguration(style_option="red")` is more accessible because users can configure the hex value of this red.
-- `RichHelpConfiguration(style_option="#FF0000")` is less accessible because it is not configurable by the end user.
+- `#!python RichHelpConfiguration(style_option="red")` is more accessible because users can configure the hex value of this red.
+- `#!python RichHelpConfiguration(style_option="#FF0000")` is less accessible because it is not configurable by the end user.

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -1,0 +1,142 @@
+# Accessibility
+
+This page goes over information relevant to both developers and users relating to accessibility considerations.
+
+Accessibility is very important to consider when developing applications.
+Colorblindness impacts roughly 4% of the general population, meaning that if your application gets even a small user base, there is a high probability that it is being used by someone with colorblindness.
+
+Fortunately, there are ways as both developers and users to address these accessibility concerns, as detailed on this page.
+
+## Colorblindness accessibility considerations for developers
+
+If you would like to make your CLI more accessible for others, there are a few rules of thumb you can follow:
+
+### 1. Use Rich features over Click features
+
+If you are using colors inside your print statements and interactive elements, you can make your CLI more accessible with the following:
+
+- Replace `click.echo()` with `rich.print()`
+- Replace `click.confirm()` with `rich.prompt.Confirm.ask()`
+- Replace `click.prompt()` with `rich.prompt.Prompt.ask()`
+
+The reason why the Rich features are more accessible than the corresponding Click features is because of the `NO_COLOR` environment variable, which the Rich library uses to disables all color. This environment variable does not work with `click.style()`, however.
+
+!!! info
+    `NO_COLOR` is a _de facto_ standard for disabling color across a wide variety of terminal programs and frameworks.
+    You can read more [here](https://no-color.org/) about the standard.
+
+So, for example:
+
+- `Confirm.ask("[red]Are you sure?[/]")` is more accessible because it works with `NO_COLOR`.
+- `click.confirm(click.echo("Are you sure?", fg="red"))` is less accessible because it cannot be overridden by `NO_COLOR`.
+
+### 2. Use 4-bit ANSI colors
+
+The 4-bit ANSI color system is a set of 16 different colors implemented in effectively every terminal, and they are the most common way to set colors.
+These colors are **not** deterministic; different terminals use slightly different hex values for the ANSI colors. [Wikipedia has a full breakdown of all the variations in these colors](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit)
+
+!!! note
+    **rich-click**'s logo references the ANSI colors! 😁
+
+There are 16 total ANSI colors: 8 base ANSI colors, with each one having a "bright" variant:
+
+- `black`
+- `red`
+- `green`
+- `yellow`
+- `blue`
+- `magenta`
+- `cyan`
+- `white`
+- `bright_black`
+- `bright_red`
+- `bright_green`
+- `bright_yellow`
+- `bright_blue`
+- `bright_magenta`
+- `bright_cyan`
+- `bright_white`
+
+Additionally, each one of these can be modified with `dim`, which in modern terminals just applies a change to the opacity of the color.
+In total, when counting `dim`, this gives developers 32 different colors that can be shown.
+
+Below is a quick script that renders all of these colors:
+
+```python
+# /// script
+# dependencies = [
+#   "rich",
+# ]
+from rich.console import Console
+from rich.box import SIMPLE
+from rich.table import Table
+
+console = Console()
+table = Table(title="ANSI Colors", box=SIMPLE)
+colors = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
+table.add_column("Color", style="bold")
+
+for variant in ["Normal", "Dim", "Bright", "Dim +\nBright"]:
+    table.add_column(variant, style="bold")
+
+for color in colors:
+    table.add_row(
+        color,
+        *[
+            f"[{style}{color}]██████[/{style}{color}]"
+            for style in ["", "dim ", "bright_", "dim bright_"]
+        ]
+    )
+
+console.print(table)
+```
+
+The fact that the colors are not deterministic is a _benefit_ for accessibility; it means, for example, a user can customize their terminal so that the ANSI "red" is more suitable for them.
+Nearly every modern terminal allows for this sort of customisation.
+
+This means that developers looking to create a more accessible experience should prefer ANSI colors.
+
+So, for example:
+
+- `RichHelpConfiguration(style_option="red")` is more accessible because users can configure the hex value of this red.
+- `RichHelpConfiguration(style_option="#FF0000")` is less accessible because it is not configurable by the end user.
+
+## Colorblindness accessibility for users
+
+If you are a user of a **rich-click** CLI, there are a few options you have to improve accessibility for yourself.
+
+### 1. Configure your terminal's 4-bit ANSI colors
+
+The 4-bit ANSI color system is a set of 16 different colors implemented in effectively every terminal, and they are the most common way to set colors.
+These colors are **not** deterministic; different terminals use slightly different hex values for the ANSI colors. [Wikipedia has a full breakdown of all the variations in these colors](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit)
+
+Most modern terminals have the ability to customise all of these colors in the terminals' settings.
+If you are having difficulty distinguishing colors, it is recommended that you adjust these settings.
+
+!!! note
+    This will only work for CLIs that utilize the 4-bit ANSI color system.
+    CLIs that utilize hex values or other color systems will not be impacted by your terminal's ANSI color settings.
+
+### 2. Use the `NO_COLOR` environment variable
+
+Rich uses the `NO_COLOR` standard ([more information here](https://no-color.org/)), which means it has a built-in capability that allows the user to suppress color.
+The Rich docs also go over additional and related console settings [here](https://rich.readthedocs.io/en/latest/console.html).
+
+So, instead of running your CLI like this:
+
+```shell
+$ python cli.py
+```
+
+You can instead do the following:
+
+```shell
+# Set environment variable, then run:
+export NO_COLOR=1
+python cli.py
+
+# ... Or run as a single line:
+NO_COLOR=1 python cli.py
+```
+
+And this will disable all colors in **rich-click**.

--- a/docs/documentation/comparison_of_click_and_rich_click.md
+++ b/docs/documentation/comparison_of_click_and_rich_click.md
@@ -105,5 +105,3 @@ Below is a side-by-side comparison of Click and Rich implementations of echos an
 
 - **rich-click** has a configuration object, `RichHelpConfiguration()`, that allows for control over how **rich-click** help text renders, so you are not just locked into the defaults. More information about this is described in [the **Configuration** docs](configuration.md).
 - **rich-click** comes with a CLI tool that allows you to convert regular Click CLIs into **rich-click** CLIs, and also lets you render your **rich-click** CLI help text as HTML and SVG. More information about this is described in [the **rich-click CLI** docs](rich_click_cli.md).
-
-**rich-click** is a slim library.

--- a/docs/documentation/comparison_of_click_and_rich_click.md
+++ b/docs/documentation/comparison_of_click_and_rich_click.md
@@ -3,7 +3,7 @@
 **rich-click** is a [shim](https://en.wikipedia.org/wiki/Shim_(computing)) around Click,
 meaning its API is designed to mirror the Click API and intercept some of the calls to slightly different functions.
 
-Everything available via `import click` is also available via `import rich_click as click`.
+Everything available via `#!python import click` is also available via `#!python import rich_click as click`.
 
 **rich-click** is designed to keep the additional API surface introduced on top of Click as lightweight as possible.
 
@@ -16,7 +16,7 @@ The only things that **rich-click** explicitly overrides in the high-level API a
 
 The only change to these decorators is that by default, their `cls=` parameters point to the **rich-click** implementations of `Command` (i.e. `RichCommand`) and `Group` (i.e. `RichGroup`).
 
-!!! info
+!!! note
     There is also a thin wrapper around `pass_context()` to cast the `click.Context` type in the function signature to `click.RichContext` to assist with static type-checking with MyPy. Aside from different typing, there are no substantive changes to the `pass_context()` decorator.
 
 ## Click features that rich-click does _not_ override
@@ -56,10 +56,12 @@ This is a deliberate decision that we are unlikely to change in the future.
 We do not want to maintain a more spread-out API surface, and we encourage users to become comfortable using Rich directly; it's a great library and it's worth learning a little bit about it!
 If you'd like Rich markup for your echos and interactive elements, then you can:
 
-- Replace `#!python click.echo()` with `#!python rich.print()` ([docs](https://rich.readthedocs.io/en/stable/introduction.html#quick-start))
-- Replace `#!python click.echo_via_pager()` with `#!python rich.Console().pager()` ([docs](https://rich.readthedocs.io/en/stable/console.html#paging))
-- Replace `#!python click.confirm()` with `#!python rich.prompt.Confirm.ask()` ([docs](https://rich.readthedocs.io/en/stable/prompt.html))
-- Replace `#!python click.prompt()` with `#!python rich.prompt.Prompt.ask()` ([docs](https://rich.readthedocs.io/en/stable/prompt.html))
+| Click Function | Rich Replacement | Rich Documentation |
+|---------------|------------------|---------------|
+| `click.echo()` | `rich.print()` | [Quick start](https://rich.readthedocs.io/en/stable/introduction.html#quick-start) |
+| `click.echo_via_pager()` | `rich.Console().pager()` | [Console](https://rich.readthedocs.io/en/stable/console.html#paging) |
+| `click.confirm()` | `rich.prompt.Confirm.ask()` | [Prompt](https://rich.readthedocs.io/en/stable/prompt.html) |
+| `click.prompt()` | `rich.prompt.Prompt.ask()` | [Prompt](https://rich.readthedocs.io/en/stable/prompt.html) |
 
 Below is a side-by-side comparison of Click and Rich implementations of echos and interactive elements in **rich-click**:
 
@@ -71,13 +73,13 @@ Below is a side-by-side comparison of Click and Rich implementations of echos an
     @click.command("greet")
     def greet():
         name = click.prompt(click.style("What is your name?", fg="blue"))
-    
+
         if not click.confirm(click.style("Are you sure?", fg="blue")):
             click.echo(click.style("Aborting", fg="red"))
             return
-    
+
         click.echo(click.style(f"Hello, {name}!", fg="green"))
-    
+
     if __name__ == "__main__":
         greet()
     ```
@@ -92,13 +94,13 @@ Below is a side-by-side comparison of Click and Rich implementations of echos an
     @click.command("greet")
     def greet():
         name = Prompt.ask("[blue]What is your name?[/]")
-    
+
         if not Confirm.ask("[blue]Are you sure?[/]"):
             rich.print("[red]Aborting[/]")
             return
-    
+
         rich.print(f"[green]Hello, {name}![/]")
-    
+
     if __name__ == "__main__":
         greet()
     ```

--- a/docs/documentation/comparison_of_click_and_rich_click.md
+++ b/docs/documentation/comparison_of_click_and_rich_click.md
@@ -1,0 +1,109 @@
+# Comparison of Click and rich-click
+
+**rich-click** is a [shim](https://en.wikipedia.org/wiki/Shim_(computing)) around Click,
+meaning its API is designed to mirror the Click API and intercept some of the calls to slightly different functions.
+
+Everything available via `import click` is also available via `import rich_click as click`.
+
+**rich-click** is designed to keep the additional API surface introduced on top of Click as lightweight as possible.
+
+## Click features that rich-click overrides
+
+The only things that **rich-click** explicitly overrides in the high-level API are the decorators:
+
+- `click.command()`
+- `click.group()`
+
+The only change to these decorators is that by default, their `cls=` parameters point to the **rich-click** implementations of `Command` (i.e. `RichCommand`) and `Group` (i.e. `RichGroup`).
+
+!!! info
+    There is also a thin wrapper around `pass_context()` to cast the `click.Context` type in the function signature to `click.RichContext` to assist with static type-checking with MyPy. Aside from different typing, there are no substantive changes to the `pass_context()` decorator.
+
+## Click features that rich-click does _not_ override
+
+### Base Click command classes
+
+You can still access the base Click classes by their original names:
+
+- `from rich_click import Command`
+- `from rich_click import Group`
+- `from rich_click import Context`
+
+The above are the same as importing from `click`.
+
+**rich-click**'s subclasses all have the word Rich in front of them!
+
+- `from rich_click import RichCommand`
+- `from rich_click import RichGroup`
+- `from rich_click import RichContext`
+
+### Echo and interactive elements
+
+**rich-click** deliberately does _not_ enrich certain Click features:
+
+- `click.echo()`
+- `click.echo_via_pager()`
+- `click.confirm()`
+- `click.prompt()`
+
+You are free to use these functions and they are available via `import rich_click as click`,
+but Rich's markup will not work with these functions because these functions are just the base Click implementations,
+without any changes.
+
+This is a deliberate decision that we are unlikely to change in the future.
+We do not want to maintain a more spread-out API surface, and we encourage users to become comfortable using Rich directly; it's a great library and it's worth learning a little bit about it!
+If you'd like Rich markup for your echos and interactive elements, then you can:
+
+- Replace `click.echo()` with `rich.print()`
+- Replace `click.echo_via_pager()` with `rich.Console().pager()`
+- Replace `click.confirm()` with `rich.prompt.Confirm.ask()`
+- Replace `click.prompt()` with `rich.prompt.Prompt.ask()`
+
+Below is a side-by-side comparison of Click and Rich implementations of echos and interactive elements in **rich-click**:
+
+=== "Click"
+
+    ```python
+    import rich_click as click
+
+    @click.command("greet")
+    def greet():
+        name = click.prompt(click.style("What is your name?", fg="blue"))
+    
+        if not click.confirm(click.style("Are you sure?", fg="blue")):
+            click.echo(click.style("Aborting", fg="red"))
+            return
+    
+        click.echo(click.style(f"Hello, {name}!", fg="green"))
+    
+    if __name__ == "__main__":
+        greet()
+    ```
+
+=== "Rich"
+
+    ```python
+    import rich_click as click
+    import rich
+    from rich.prompt import Confirm, Prompt
+
+    @click.command("greet")
+    def greet():
+        name = Prompt.ask("[blue]What is your name?[/]")
+    
+        if not Confirm.ask("[blue]Are you sure?[/]"):
+            rich.print("[red]Aborting[/]"))
+            return
+    
+        rich.print(f"[green]Hello, {name}![/]")
+    
+    if __name__ == "__main__":
+        greet()
+    ```
+
+## Additional rich-click features
+
+- **rich-click** has a configuration object, `RichHelpConfiguration()`, that allows for control over how **rich-click** help text renders, so you are not just locked into the defaults. More information about this is described in [the **Configuration** docs](configuration.md).
+- **rich-click** comes with a CLI tool that allows you to convert regular Click CLIs into **rich-click** CLIs, and also lets you render your **rich-click** CLI help text as HTML and SVG. More information about this is described in [the **rich-click CLI** docs](rich_click_cli.md).
+
+**rich-click** is a slim library.

--- a/docs/documentation/comparison_of_click_and_rich_click.md
+++ b/docs/documentation/comparison_of_click_and_rich_click.md
@@ -25,28 +25,30 @@ The only change to these decorators is that by default, their `cls=` parameters 
 
 You can still access the base Click classes by their original names:
 
-- `from rich_click import Command`
-- `from rich_click import Group`
-- `from rich_click import Context`
+```python
+from rich_click import Command, Group, Context
+```
 
 The above are the same as importing from `click`.
 
 **rich-click**'s subclasses all have the word Rich in front of them!
 
-- `from rich_click import RichCommand`
-- `from rich_click import RichGroup`
-- `from rich_click import RichContext`
+```python
+from rich_click import RichCommand, RichGroup, RichContext
+```
 
 ### Echo and interactive elements
 
 **rich-click** deliberately does _not_ enrich certain Click features:
 
-- `click.echo()`
-- `click.echo_via_pager()`
-- `click.confirm()`
-- `click.prompt()`
+```python
+click.echo()
+click.echo_via_pager()
+click.confirm()
+click.prompt()
+```
 
-You are free to use these functions and they are available via `import rich_click as click`,
+You are free to use these functions and they are available via `#!python import rich_click as click`,
 but Rich's markup will not work with these functions because these functions are just the base Click implementations,
 without any changes.
 
@@ -54,10 +56,10 @@ This is a deliberate decision that we are unlikely to change in the future.
 We do not want to maintain a more spread-out API surface, and we encourage users to become comfortable using Rich directly; it's a great library and it's worth learning a little bit about it!
 If you'd like Rich markup for your echos and interactive elements, then you can:
 
-- Replace `click.echo()` with `rich.print()`
-- Replace `click.echo_via_pager()` with `rich.Console().pager()`
-- Replace `click.confirm()` with `rich.prompt.Confirm.ask()`
-- Replace `click.prompt()` with `rich.prompt.Prompt.ask()`
+- Replace `#!python click.echo()` with `#!python rich.print()` ([docs](https://rich.readthedocs.io/en/stable/introduction.html#quick-start))
+- Replace `#!python click.echo_via_pager()` with `#!python rich.Console().pager()` ([docs](https://rich.readthedocs.io/en/stable/console.html#paging))
+- Replace `#!python click.confirm()` with `#!python rich.prompt.Confirm.ask()` ([docs](https://rich.readthedocs.io/en/stable/prompt.html))
+- Replace `#!python click.prompt()` with `#!python rich.prompt.Prompt.ask()` ([docs](https://rich.readthedocs.io/en/stable/prompt.html))
 
 Below is a side-by-side comparison of Click and Rich implementations of echos and interactive elements in **rich-click**:
 
@@ -92,7 +94,7 @@ Below is a side-by-side comparison of Click and Rich implementations of echos an
         name = Prompt.ask("[blue]What is your name?[/]")
     
         if not Confirm.ask("[blue]Are you sure?[/]"):
-            rich.print("[red]Aborting[/]"))
+            rich.print("[red]Aborting[/]")
             return
     
         rich.print(f"[green]Hello, {name}![/]")

--- a/docs/documentation/configuration.md
+++ b/docs/documentation/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-There are two methods to configure rich-click:
+There are two methods to configure **rich-click**:
 
 - Decorator: Use the `@rich_config()` decorator (and `RichHelpConfiguration()`).
 - Globals: Set the global variables in the `rich_config.rich_config` module.

--- a/docs/documentation/formatting_and_styles.md
+++ b/docs/documentation/formatting_and_styles.md
@@ -238,5 +238,5 @@ extra_env:
 
 > See [`examples/10_table_styles.py`](https://github.com/ewels/rich-click/blob/main/examples/10_table_styles.py) for an example.
 
-See the [_Configuration options_](#configuration-options) section below for the full list of available options.
+See the [_Configuration options_](configuration.md#configuration-options) section below for the full list of available options.
 

--- a/docs/documentation/formatting_and_styles.md
+++ b/docs/documentation/formatting_and_styles.md
@@ -6,7 +6,7 @@
 
 ## Formatting
 
-There are a large number of customisation options in rich-click.
+There are a large number of customization options in rich-click.
 These can be modified by changing variables in the `click.rich_click` namespace.
 
 Note that most normal click options should still work, such as `show_default=True`, `required=True` and `hidden=True`.
@@ -158,7 +158,7 @@ working_dir: .
 -->
 ![`python examples/01_simple.py --hep || true`](../images/error.svg "Error message"){.screenshot}
 
-You can customise the _Try 'command --help' for help._ message with `ERRORS_SUGGESTION`
+You can customize the _Try 'command --help' for help._ message with `ERRORS_SUGGESTION`
 using rich-click though, and add some text after the error with `ERRORS_EPILOGUE`.
 
 For example, from [`examples/07_custom_errors.py`](https://github.com/ewels/rich-click/blob/main/examples/07_custom_errors.py):
@@ -211,7 +211,7 @@ Setting `MAX_WIDTH` overrides the effect of `WIDTH`
 !!! success
     Check out the [**Live Style Editor**](../editor.md) to easily get started building a custom **rich-click** style!
 
-Most aspects of rich-click formatting can be customised, from color to alignment.
+Most aspects of rich-click formatting can be customized, from color to alignment.
 
 For example, to print the option flags in a different color, you can use:
 

--- a/docs/documentation/formatting_and_styles.md
+++ b/docs/documentation/formatting_and_styles.md
@@ -211,9 +211,9 @@ Setting `MAX_WIDTH` overrides the effect of `WIDTH`
 !!! success
     Check out the [**Live Style Editor**](../editor.md) to easily get started building a custom **rich-click** style!
 
-Most aspects of rich-click formatting can be customised, from colours to alignment.
+Most aspects of rich-click formatting can be customised, from color to alignment.
 
-For example, to print the option flags in a different colour, you can use:
+For example, to print the option flags in a different color, you can use:
 
 ```python
 click.rich_click.STYLE_OPTION = "magenta"
@@ -226,7 +226,7 @@ click.rich_click.STYLE_OPTIONS_TABLE_LEADING = 1
 click.rich_click.STYLE_OPTIONS_TABLE_BOX = "SIMPLE"
 ```
 
-You can make some really ~horrible~ _colourful_ solutions using these styles if you wish:
+You can make some really ~horrible~ _colorful_ solutions using these styles if you wish:
 
 <!-- RICH-CODEX
 working_dir: .

--- a/docs/images/code_snippets/accessibility/colors.svg
+++ b/docs/images/code_snippets/accessibility/colors.svg
@@ -1,0 +1,114 @@
+<svg class="rich-terminal" viewBox="0 0 994 416.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-119970904-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-119970904-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-119970904-r1 { fill: #c5c8c6 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-119970904-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="365.0" />
+    </clipPath>
+    <clipPath id="terminal-119970904-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-119970904-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="414" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-119970904-clip-terminal)">
+    
+    <g class="terminal-119970904-matrix">
+    <text class="terminal-119970904-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-119970904-line-0)">$&#160;python&#160;colors.py</text><text class="terminal-119970904-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-119970904-line-0)">
+</text><text class="terminal-119970904-r1" x="0" y="44.4" textLength="573.4" clip-path="url(#terminal-119970904-line-1)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;ANSI&#160;Colors&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-119970904-line-1)">
+</text><text class="terminal-119970904-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-119970904-line-2)">
+</text><text class="terminal-119970904-r1" x="0" y="93.2" textLength="573.4" clip-path="url(#terminal-119970904-line-3)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Dim&#160;+&#160;&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-119970904-line-3)">
+</text><text class="terminal-119970904-r1" x="0" y="117.6" textLength="573.4" clip-path="url(#terminal-119970904-line-4)">&#160;&#160;Color&#160;&#160;&#160;&#160;&#160;Normal&#160;&#160;&#160;Dim&#160;&#160;&#160;&#160;&#160;&#160;Bright&#160;&#160;&#160;Bright&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-119970904-line-4)">
+</text><text class="terminal-119970904-r1" x="0" y="142" textLength="573.4" clip-path="url(#terminal-119970904-line-5)">&#160;─────────────────────────────────────────────&#160;</text><text class="terminal-119970904-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-119970904-line-5)">
+</text><text class="terminal-119970904-r1" x="0" y="166.4" textLength="573.4" clip-path="url(#terminal-119970904-line-6)">&#160;&#160;black&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-119970904-line-6)">
+</text><text class="terminal-119970904-r1" x="0" y="190.8" textLength="573.4" clip-path="url(#terminal-119970904-line-7)">&#160;&#160;red&#160;&#160;&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-119970904-line-7)">
+</text><text class="terminal-119970904-r1" x="0" y="215.2" textLength="573.4" clip-path="url(#terminal-119970904-line-8)">&#160;&#160;green&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-119970904-line-8)">
+</text><text class="terminal-119970904-r1" x="0" y="239.6" textLength="573.4" clip-path="url(#terminal-119970904-line-9)">&#160;&#160;yellow&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-119970904-line-9)">
+</text><text class="terminal-119970904-r1" x="0" y="264" textLength="573.4" clip-path="url(#terminal-119970904-line-10)">&#160;&#160;blue&#160;&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-119970904-line-10)">
+</text><text class="terminal-119970904-r1" x="0" y="288.4" textLength="573.4" clip-path="url(#terminal-119970904-line-11)">&#160;&#160;magenta&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-119970904-line-11)">
+</text><text class="terminal-119970904-r1" x="0" y="312.8" textLength="573.4" clip-path="url(#terminal-119970904-line-12)">&#160;&#160;cyan&#160;&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-119970904-line-12)">
+</text><text class="terminal-119970904-r1" x="0" y="337.2" textLength="573.4" clip-path="url(#terminal-119970904-line-13)">&#160;&#160;white&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-119970904-line-13)">
+</text><text class="terminal-119970904-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-119970904-line-14)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/code_snippets/accessibility/colors.svg
+++ b/docs/images/code_snippets/accessibility/colors.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 416.0" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 604 391.59999999999997" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,95 +19,124 @@
         font-weight: 700;
     }
 
-    .terminal-119970904-matrix {
+    .terminal-3112216171-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-119970904-title {
+    .terminal-3112216171-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-119970904-r1 { fill: #c5c8c6 }
+    .terminal-3112216171-r1 { fill: #c5c8c6;font-style: italic; }
+.terminal-3112216171-r2 { fill: #c5c8c6 }
+.terminal-3112216171-r3 { fill: #c5c8c6;font-weight: bold }
+.terminal-3112216171-r4 { fill: #4b4e55;font-weight: bold }
+.terminal-3112216171-r5 { fill: #3d3f43;font-weight: bold }
+.terminal-3112216171-r6 { fill: #9a9b99;font-weight: bold }
+.terminal-3112216171-r7 { fill: #6c6d6c;font-weight: bold }
+.terminal-3112216171-r8 { fill: #cc555a;font-weight: bold }
+.terminal-3112216171-r9 { fill: #8a4346;font-weight: bold }
+.terminal-3112216171-r10 { fill: #ff2627;font-weight: bold }
+.terminal-3112216171-r11 { fill: #a92727;font-weight: bold }
+.terminal-3112216171-r12 { fill: #98a84b;font-weight: bold }
+.terminal-3112216171-r13 { fill: #6b753d;font-weight: bold }
+.terminal-3112216171-r14 { fill: #00823d;font-weight: bold }
+.terminal-3112216171-r15 { fill: #105e35;font-weight: bold }
+.terminal-3112216171-r16 { fill: #d0b344;font-weight: bold }
+.terminal-3112216171-r17 { fill: #8d7b39;font-weight: bold }
+.terminal-3112216171-r18 { fill: #d08442;font-weight: bold }
+.terminal-3112216171-r19 { fill: #8d5f38;font-weight: bold }
+.terminal-3112216171-r20 { fill: #608ab1;font-weight: bold }
+.terminal-3112216171-r21 { fill: #4a637a;font-weight: bold }
+.terminal-3112216171-r22 { fill: #1984e9;font-weight: bold }
+.terminal-3112216171-r23 { fill: #1f5f9c;font-weight: bold }
+.terminal-3112216171-r24 { fill: #98729f;font-weight: bold }
+.terminal-3112216171-r25 { fill: #6b546f;font-weight: bold }
+.terminal-3112216171-r26 { fill: #ff2c7a;font-weight: bold }
+.terminal-3112216171-r27 { fill: #a92a59;font-weight: bold }
+.terminal-3112216171-r28 { fill: #68a0b3;font-weight: bold }
+.terminal-3112216171-r29 { fill: #4e707b;font-weight: bold }
+.terminal-3112216171-r30 { fill: #398280;font-weight: bold }
+.terminal-3112216171-r31 { fill: #325e5d;font-weight: bold }
+.terminal-3112216171-r32 { fill: #868887;font-weight: bold }
+.terminal-3112216171-r33 { fill: #fdfdc5;font-weight: bold }
+.terminal-3112216171-r34 { fill: #a8a886;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-119970904-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="365.0" />
+    <clipPath id="terminal-3112216171-clip-terminal">
+      <rect x="0" y="0" width="584.5999999999999" height="340.59999999999997" />
     </clipPath>
-    <clipPath id="terminal-119970904-line-0">
-    <rect x="0" y="1.5" width="976" height="24.65"/>
+    <clipPath id="terminal-3112216171-line-0">
+    <rect x="0" y="1.5" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-1">
-    <rect x="0" y="25.9" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-1">
+    <rect x="0" y="25.9" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-2">
-    <rect x="0" y="50.3" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-2">
+    <rect x="0" y="50.3" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-3">
-    <rect x="0" y="74.7" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-3">
+    <rect x="0" y="74.7" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-4">
-    <rect x="0" y="99.1" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-4">
+    <rect x="0" y="99.1" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-5">
-    <rect x="0" y="123.5" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-5">
+    <rect x="0" y="123.5" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-6">
-    <rect x="0" y="147.9" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-6">
+    <rect x="0" y="147.9" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-7">
-    <rect x="0" y="172.3" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-7">
+    <rect x="0" y="172.3" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-8">
-    <rect x="0" y="196.7" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-8">
+    <rect x="0" y="196.7" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-9">
-    <rect x="0" y="221.1" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-9">
+    <rect x="0" y="221.1" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-10">
-    <rect x="0" y="245.5" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-10">
+    <rect x="0" y="245.5" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-11">
-    <rect x="0" y="269.9" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-11">
+    <rect x="0" y="269.9" width="585.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-119970904-line-12">
-    <rect x="0" y="294.3" width="976" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-119970904-line-13">
-    <rect x="0" y="318.7" width="976" height="24.65"/>
+<clipPath id="terminal-3112216171-line-12">
+    <rect x="0" y="294.3" width="585.6" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="414" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="602" height="389.6" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-119970904-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3112216171-clip-terminal)">
     
-    <g class="terminal-119970904-matrix">
-    <text class="terminal-119970904-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-119970904-line-0)">$&#160;python&#160;colors.py</text><text class="terminal-119970904-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-119970904-line-0)">
-</text><text class="terminal-119970904-r1" x="0" y="44.4" textLength="573.4" clip-path="url(#terminal-119970904-line-1)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;ANSI&#160;Colors&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-119970904-line-1)">
-</text><text class="terminal-119970904-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-119970904-line-2)">
-</text><text class="terminal-119970904-r1" x="0" y="93.2" textLength="573.4" clip-path="url(#terminal-119970904-line-3)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Dim&#160;+&#160;&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-119970904-line-3)">
-</text><text class="terminal-119970904-r1" x="0" y="117.6" textLength="573.4" clip-path="url(#terminal-119970904-line-4)">&#160;&#160;Color&#160;&#160;&#160;&#160;&#160;Normal&#160;&#160;&#160;Dim&#160;&#160;&#160;&#160;&#160;&#160;Bright&#160;&#160;&#160;Bright&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-119970904-line-4)">
-</text><text class="terminal-119970904-r1" x="0" y="142" textLength="573.4" clip-path="url(#terminal-119970904-line-5)">&#160;─────────────────────────────────────────────&#160;</text><text class="terminal-119970904-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-119970904-line-5)">
-</text><text class="terminal-119970904-r1" x="0" y="166.4" textLength="573.4" clip-path="url(#terminal-119970904-line-6)">&#160;&#160;black&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-119970904-line-6)">
-</text><text class="terminal-119970904-r1" x="0" y="190.8" textLength="573.4" clip-path="url(#terminal-119970904-line-7)">&#160;&#160;red&#160;&#160;&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-119970904-line-7)">
-</text><text class="terminal-119970904-r1" x="0" y="215.2" textLength="573.4" clip-path="url(#terminal-119970904-line-8)">&#160;&#160;green&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-119970904-line-8)">
-</text><text class="terminal-119970904-r1" x="0" y="239.6" textLength="573.4" clip-path="url(#terminal-119970904-line-9)">&#160;&#160;yellow&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-119970904-line-9)">
-</text><text class="terminal-119970904-r1" x="0" y="264" textLength="573.4" clip-path="url(#terminal-119970904-line-10)">&#160;&#160;blue&#160;&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-119970904-line-10)">
-</text><text class="terminal-119970904-r1" x="0" y="288.4" textLength="573.4" clip-path="url(#terminal-119970904-line-11)">&#160;&#160;magenta&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-119970904-line-11)">
-</text><text class="terminal-119970904-r1" x="0" y="312.8" textLength="573.4" clip-path="url(#terminal-119970904-line-12)">&#160;&#160;cyan&#160;&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-119970904-line-12)">
-</text><text class="terminal-119970904-r1" x="0" y="337.2" textLength="573.4" clip-path="url(#terminal-119970904-line-13)">&#160;&#160;white&#160;&#160;&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;&#160;██████&#160;&#160;</text><text class="terminal-119970904-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-119970904-line-13)">
-</text><text class="terminal-119970904-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-119970904-line-14)">
+    <g class="terminal-3112216171-matrix">
+    <text class="terminal-3112216171-r1" x="0" y="20" textLength="573.4" clip-path="url(#terminal-3112216171-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;ANSI&#160;Colors&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3112216171-r2" x="585.6" y="20" textLength="12.2" clip-path="url(#terminal-3112216171-line-0)">
+</text><text class="terminal-3112216171-r2" x="585.6" y="44.4" textLength="12.2" clip-path="url(#terminal-3112216171-line-1)">
+</text><text class="terminal-3112216171-r3" x="475.8" y="68.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-2)">Dim&#160;+&#160;</text><text class="terminal-3112216171-r2" x="585.6" y="68.8" textLength="12.2" clip-path="url(#terminal-3112216171-line-2)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="93.2" textLength="85.4" clip-path="url(#terminal-3112216171-line-3)">Color&#160;&#160;</text><text class="terminal-3112216171-r3" x="146.4" y="93.2" textLength="73.2" clip-path="url(#terminal-3112216171-line-3)">Normal</text><text class="terminal-3112216171-r3" x="256.2" y="93.2" textLength="73.2" clip-path="url(#terminal-3112216171-line-3)">Dim&#160;&#160;&#160;</text><text class="terminal-3112216171-r3" x="366" y="93.2" textLength="73.2" clip-path="url(#terminal-3112216171-line-3)">Bright</text><text class="terminal-3112216171-r3" x="475.8" y="93.2" textLength="73.2" clip-path="url(#terminal-3112216171-line-3)">Bright</text><text class="terminal-3112216171-r2" x="585.6" y="93.2" textLength="12.2" clip-path="url(#terminal-3112216171-line-3)">
+</text><text class="terminal-3112216171-r2" x="0" y="117.6" textLength="573.4" clip-path="url(#terminal-3112216171-line-4)">&#160;─────────────────────────────────────────────&#160;</text><text class="terminal-3112216171-r2" x="585.6" y="117.6" textLength="12.2" clip-path="url(#terminal-3112216171-line-4)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="142" textLength="85.4" clip-path="url(#terminal-3112216171-line-5)">black&#160;&#160;</text><text class="terminal-3112216171-r4" x="146.4" y="142" textLength="73.2" clip-path="url(#terminal-3112216171-line-5)">██████</text><text class="terminal-3112216171-r5" x="256.2" y="142" textLength="73.2" clip-path="url(#terminal-3112216171-line-5)">██████</text><text class="terminal-3112216171-r6" x="366" y="142" textLength="73.2" clip-path="url(#terminal-3112216171-line-5)">██████</text><text class="terminal-3112216171-r7" x="475.8" y="142" textLength="73.2" clip-path="url(#terminal-3112216171-line-5)">██████</text><text class="terminal-3112216171-r2" x="585.6" y="142" textLength="12.2" clip-path="url(#terminal-3112216171-line-5)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="166.4" textLength="85.4" clip-path="url(#terminal-3112216171-line-6)">red&#160;&#160;&#160;&#160;</text><text class="terminal-3112216171-r8" x="146.4" y="166.4" textLength="73.2" clip-path="url(#terminal-3112216171-line-6)">██████</text><text class="terminal-3112216171-r9" x="256.2" y="166.4" textLength="73.2" clip-path="url(#terminal-3112216171-line-6)">██████</text><text class="terminal-3112216171-r10" x="366" y="166.4" textLength="73.2" clip-path="url(#terminal-3112216171-line-6)">██████</text><text class="terminal-3112216171-r11" x="475.8" y="166.4" textLength="73.2" clip-path="url(#terminal-3112216171-line-6)">██████</text><text class="terminal-3112216171-r2" x="585.6" y="166.4" textLength="12.2" clip-path="url(#terminal-3112216171-line-6)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="190.8" textLength="85.4" clip-path="url(#terminal-3112216171-line-7)">green&#160;&#160;</text><text class="terminal-3112216171-r12" x="146.4" y="190.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-7)">██████</text><text class="terminal-3112216171-r13" x="256.2" y="190.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-7)">██████</text><text class="terminal-3112216171-r14" x="366" y="190.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-7)">██████</text><text class="terminal-3112216171-r15" x="475.8" y="190.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-7)">██████</text><text class="terminal-3112216171-r2" x="585.6" y="190.8" textLength="12.2" clip-path="url(#terminal-3112216171-line-7)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="215.2" textLength="85.4" clip-path="url(#terminal-3112216171-line-8)">yellow&#160;</text><text class="terminal-3112216171-r16" x="146.4" y="215.2" textLength="73.2" clip-path="url(#terminal-3112216171-line-8)">██████</text><text class="terminal-3112216171-r17" x="256.2" y="215.2" textLength="73.2" clip-path="url(#terminal-3112216171-line-8)">██████</text><text class="terminal-3112216171-r18" x="366" y="215.2" textLength="73.2" clip-path="url(#terminal-3112216171-line-8)">██████</text><text class="terminal-3112216171-r19" x="475.8" y="215.2" textLength="73.2" clip-path="url(#terminal-3112216171-line-8)">██████</text><text class="terminal-3112216171-r2" x="585.6" y="215.2" textLength="12.2" clip-path="url(#terminal-3112216171-line-8)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="239.6" textLength="85.4" clip-path="url(#terminal-3112216171-line-9)">blue&#160;&#160;&#160;</text><text class="terminal-3112216171-r20" x="146.4" y="239.6" textLength="73.2" clip-path="url(#terminal-3112216171-line-9)">██████</text><text class="terminal-3112216171-r21" x="256.2" y="239.6" textLength="73.2" clip-path="url(#terminal-3112216171-line-9)">██████</text><text class="terminal-3112216171-r22" x="366" y="239.6" textLength="73.2" clip-path="url(#terminal-3112216171-line-9)">██████</text><text class="terminal-3112216171-r23" x="475.8" y="239.6" textLength="73.2" clip-path="url(#terminal-3112216171-line-9)">██████</text><text class="terminal-3112216171-r2" x="585.6" y="239.6" textLength="12.2" clip-path="url(#terminal-3112216171-line-9)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="264" textLength="85.4" clip-path="url(#terminal-3112216171-line-10)">magenta</text><text class="terminal-3112216171-r24" x="146.4" y="264" textLength="73.2" clip-path="url(#terminal-3112216171-line-10)">██████</text><text class="terminal-3112216171-r25" x="256.2" y="264" textLength="73.2" clip-path="url(#terminal-3112216171-line-10)">██████</text><text class="terminal-3112216171-r26" x="366" y="264" textLength="73.2" clip-path="url(#terminal-3112216171-line-10)">██████</text><text class="terminal-3112216171-r27" x="475.8" y="264" textLength="73.2" clip-path="url(#terminal-3112216171-line-10)">██████</text><text class="terminal-3112216171-r2" x="585.6" y="264" textLength="12.2" clip-path="url(#terminal-3112216171-line-10)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="288.4" textLength="85.4" clip-path="url(#terminal-3112216171-line-11)">cyan&#160;&#160;&#160;</text><text class="terminal-3112216171-r28" x="146.4" y="288.4" textLength="73.2" clip-path="url(#terminal-3112216171-line-11)">██████</text><text class="terminal-3112216171-r29" x="256.2" y="288.4" textLength="73.2" clip-path="url(#terminal-3112216171-line-11)">██████</text><text class="terminal-3112216171-r30" x="366" y="288.4" textLength="73.2" clip-path="url(#terminal-3112216171-line-11)">██████</text><text class="terminal-3112216171-r31" x="475.8" y="288.4" textLength="73.2" clip-path="url(#terminal-3112216171-line-11)">██████</text><text class="terminal-3112216171-r2" x="585.6" y="288.4" textLength="12.2" clip-path="url(#terminal-3112216171-line-11)">
+</text><text class="terminal-3112216171-r3" x="24.4" y="312.8" textLength="85.4" clip-path="url(#terminal-3112216171-line-12)">white&#160;&#160;</text><text class="terminal-3112216171-r3" x="146.4" y="312.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-12)">██████</text><text class="terminal-3112216171-r32" x="256.2" y="312.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-12)">██████</text><text class="terminal-3112216171-r33" x="366" y="312.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-12)">██████</text><text class="terminal-3112216171-r34" x="475.8" y="312.8" textLength="73.2" clip-path="url(#terminal-3112216171-line-12)">██████</text><text class="terminal-3112216171-r2" x="585.6" y="312.8" textLength="12.2" clip-path="url(#terminal-3112216171-line-12)">
+</text><text class="terminal-3112216171-r2" x="585.6" y="337.2" textLength="12.2" clip-path="url(#terminal-3112216171-line-13)">
 </text>
     </g>
     </g>

--- a/docs/images/code_snippets/rich_click_cli/rich_click.svg
+++ b/docs/images/code_snippets/rich_click_cli/rich_click.svg
@@ -19,70 +19,70 @@
         font-weight: 700;
     }
 
-    .terminal-443070625-matrix {
+    .terminal-539408552-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-443070625-title {
+    .terminal-539408552-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-443070625-r1 { fill: #c5c8c6 }
-.terminal-443070625-r2 { fill: #d0b344 }
-.terminal-443070625-r3 { fill: #c5c8c6;font-weight: bold }
-.terminal-443070625-r4 { fill: #68a0b3;font-weight: bold }
-.terminal-443070625-r5 { fill: #868887 }
-.terminal-443070625-r6 { fill: #4e707b;font-weight: bold }
-.terminal-443070625-r7 { fill: #868887;font-weight: bold }
-.terminal-443070625-r8 { fill: #868887;font-style: italic; }
+    .terminal-539408552-r1 { fill: #c5c8c6 }
+.terminal-539408552-r2 { fill: #d0b344 }
+.terminal-539408552-r3 { fill: #c5c8c6;font-weight: bold }
+.terminal-539408552-r4 { fill: #68a0b3;font-weight: bold }
+.terminal-539408552-r5 { fill: #868887 }
+.terminal-539408552-r6 { fill: #4e707b;font-weight: bold }
+.terminal-539408552-r7 { fill: #868887;font-weight: bold }
+.terminal-539408552-r8 { fill: #868887;font-style: italic; }
     </style>
 
     <defs>
-    <clipPath id="terminal-443070625-clip-terminal">
+    <clipPath id="terminal-539408552-clip-terminal">
       <rect x="0" y="0" width="975.0" height="340.59999999999997" />
     </clipPath>
-    <clipPath id="terminal-443070625-line-0">
+    <clipPath id="terminal-539408552-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-1">
+<clipPath id="terminal-539408552-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-2">
+<clipPath id="terminal-539408552-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-3">
+<clipPath id="terminal-539408552-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-4">
+<clipPath id="terminal-539408552-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-5">
+<clipPath id="terminal-539408552-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-6">
+<clipPath id="terminal-539408552-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-7">
+<clipPath id="terminal-539408552-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-8">
+<clipPath id="terminal-539408552-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-9">
+<clipPath id="terminal-539408552-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-10">
+<clipPath id="terminal-539408552-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-11">
+<clipPath id="terminal-539408552-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-443070625-line-12">
+<clipPath id="terminal-539408552-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
@@ -94,23 +94,23 @@
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-443070625-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-539408552-clip-terminal)">
     
-    <g class="terminal-443070625-matrix">
-    <text class="terminal-443070625-r1" x="0" y="20" textLength="231.8" clip-path="url(#terminal-443070625-line-0)">$&#160;rich-click&#160;--help</text><text class="terminal-443070625-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-443070625-line-0)">
-</text><text class="terminal-443070625-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-443070625-line-1)">
-</text><text class="terminal-443070625-r2" x="12.2" y="68.8" textLength="744.2" clip-path="url(#terminal-443070625-line-2)">Usage:&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-443070625-r3" x="768.6" y="68.8" textLength="122" clip-path="url(#terminal-443070625-line-2)">rich-click</text><text class="terminal-443070625-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-443070625-line-2)">
-</text><text class="terminal-443070625-r1" x="0" y="93.2" textLength="24.4" clip-path="url(#terminal-443070625-line-3)">&#160;[</text><text class="terminal-443070625-r4" x="24.4" y="93.2" textLength="85.4" clip-path="url(#terminal-443070625-line-3)">OPTIONS</text><text class="terminal-443070625-r1" x="109.8" y="93.2" textLength="36.6" clip-path="url(#terminal-443070625-line-3)">]&#160;[</text><text class="terminal-443070625-r4" x="146.4" y="93.2" textLength="73.2" clip-path="url(#terminal-443070625-line-3)">SCRIPT</text><text class="terminal-443070625-r1" x="219.6" y="93.2" textLength="36.6" clip-path="url(#terminal-443070625-line-3)">&#160;|&#160;</text><text class="terminal-443070625-r4" x="256.2" y="93.2" textLength="73.2" clip-path="url(#terminal-443070625-line-3)">MODULE</text><text class="terminal-443070625-r1" x="329.4" y="93.2" textLength="12.2" clip-path="url(#terminal-443070625-line-3)">:</text><text class="terminal-443070625-r4" x="341.6" y="93.2" textLength="158.6" clip-path="url(#terminal-443070625-line-3)">CLICK_COMMAND</text><text class="terminal-443070625-r1" x="500.2" y="93.2" textLength="73.2" clip-path="url(#terminal-443070625-line-3)">]&#160;[--&#160;</text><text class="terminal-443070625-r4" x="573.4" y="93.2" textLength="134.2" clip-path="url(#terminal-443070625-line-3)">SCRIPT_ARGS</text><text class="terminal-443070625-r1" x="707.6" y="93.2" textLength="268.4" clip-path="url(#terminal-443070625-line-3)">...]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-443070625-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-443070625-line-3)">
-</text><text class="terminal-443070625-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-443070625-line-4)">
-</text><text class="terminal-443070625-r1" x="0" y="142" textLength="61" clip-path="url(#terminal-443070625-line-5)">&#160;The&#160;</text><text class="terminal-443070625-r1" x="61" y="142" textLength="122" clip-path="url(#terminal-443070625-line-5)">rich-click</text><text class="terminal-443070625-r1" x="183" y="142" textLength="695.4" clip-path="url(#terminal-443070625-line-5)">&#160;CLI&#160;provides&#160;attractive&#160;help&#160;output&#160;from&#160;any&#160;tool&#160;using&#160;</text><text class="terminal-443070625-r1" x="878.4" y="142" textLength="61" clip-path="url(#terminal-443070625-line-5)">click</text><text class="terminal-443070625-r1" x="939.4" y="142" textLength="36.6" clip-path="url(#terminal-443070625-line-5)">,&#160;&#160;</text><text class="terminal-443070625-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-443070625-line-5)">
-</text><text class="terminal-443070625-r1" x="0" y="166.4" textLength="195.2" clip-path="url(#terminal-443070625-line-6)">&#160;formatted&#160;with&#160;</text><text class="terminal-443070625-r1" x="195.2" y="166.4" textLength="48.8" clip-path="url(#terminal-443070625-line-6)">rich</text><text class="terminal-443070625-r1" x="244" y="166.4" textLength="732" clip-path="url(#terminal-443070625-line-6)">.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-443070625-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-443070625-line-6)">
-</text><text class="terminal-443070625-r5" x="12.2" y="190.8" textLength="927.2" clip-path="url(#terminal-443070625-line-7)">The&#160;rich-click&#160;command&#160;line&#160;tool&#160;can&#160;be&#160;prepended&#160;before&#160;any&#160;Python&#160;package&#160;</text><text class="terminal-443070625-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-443070625-line-7)">
-</text><text class="terminal-443070625-r5" x="12.2" y="215.2" textLength="841.8" clip-path="url(#terminal-443070625-line-8)">using&#160;native&#160;click&#160;to&#160;provide&#160;attractive&#160;richified&#160;click&#160;help&#160;output.</text><text class="terminal-443070625-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-443070625-line-8)">
-</text><text class="terminal-443070625-r5" x="12.2" y="239.6" textLength="512.4" clip-path="url(#terminal-443070625-line-9)">For&#160;example,&#160;if&#160;you&#160;have&#160;a&#160;package&#160;called&#160;</text><text class="terminal-443070625-r6" x="524.6" y="239.6" textLength="122" clip-path="url(#terminal-443070625-line-9)">my_package</text><text class="terminal-443070625-r5" x="646.6" y="239.6" textLength="317.2" clip-path="url(#terminal-443070625-line-9)">&#160;that&#160;uses&#160;click,&#160;you&#160;can&#160;</text><text class="terminal-443070625-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-443070625-line-9)">
-</text><text class="terminal-443070625-r5" x="12.2" y="264" textLength="48.8" clip-path="url(#terminal-443070625-line-10)">run:</text><text class="terminal-443070625-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-443070625-line-10)">
-</text><text class="terminal-443070625-r5" x="12.2" y="288.4" textLength="48.8" clip-path="url(#terminal-443070625-line-11)">&gt;&gt;&gt;&#160;</text><text class="terminal-443070625-r6" x="61" y="288.4" textLength="122" clip-path="url(#terminal-443070625-line-11)">rich-click</text><text class="terminal-443070625-r6" x="195.2" y="288.4" textLength="122" clip-path="url(#terminal-443070625-line-11)">my_package</text><text class="terminal-443070625-r6" x="329.4" y="288.4" textLength="73.2" clip-path="url(#terminal-443070625-line-11)">--help</text><text class="terminal-443070625-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-443070625-line-11)">
-</text><text class="terminal-443070625-r5" x="12.2" y="312.8" textLength="744.2" clip-path="url(#terminal-443070625-line-12)">This&#160;does&#160;not&#160;always&#160;work&#160;if&#160;the&#160;package&#160;is&#160;using&#160;customised&#160;</text><text class="terminal-443070625-r7" x="756.4" y="312.8" textLength="158.6" clip-path="url(#terminal-443070625-line-12)">click.group()</text><text class="terminal-443070625-r5" x="915" y="312.8" textLength="48.8" clip-path="url(#terminal-443070625-line-12)">&#160;or&#160;</text><text class="terminal-443070625-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-443070625-line-12)">
-</text><text class="terminal-443070625-r8" x="0" y="337.2" textLength="183" clip-path="url(#terminal-443070625-line-13)">[..truncated..]</text><text class="terminal-443070625-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-443070625-line-13)">
+    <g class="terminal-539408552-matrix">
+    <text class="terminal-539408552-r1" x="0" y="20" textLength="231.8" clip-path="url(#terminal-539408552-line-0)">$&#160;rich-click&#160;--help</text><text class="terminal-539408552-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-539408552-line-0)">
+</text><text class="terminal-539408552-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-539408552-line-1)">
+</text><text class="terminal-539408552-r2" x="12.2" y="68.8" textLength="744.2" clip-path="url(#terminal-539408552-line-2)">Usage:&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-539408552-r3" x="768.6" y="68.8" textLength="122" clip-path="url(#terminal-539408552-line-2)">rich-click</text><text class="terminal-539408552-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-539408552-line-2)">
+</text><text class="terminal-539408552-r1" x="0" y="93.2" textLength="24.4" clip-path="url(#terminal-539408552-line-3)">&#160;[</text><text class="terminal-539408552-r4" x="24.4" y="93.2" textLength="85.4" clip-path="url(#terminal-539408552-line-3)">OPTIONS</text><text class="terminal-539408552-r1" x="109.8" y="93.2" textLength="36.6" clip-path="url(#terminal-539408552-line-3)">]&#160;[</text><text class="terminal-539408552-r4" x="146.4" y="93.2" textLength="73.2" clip-path="url(#terminal-539408552-line-3)">SCRIPT</text><text class="terminal-539408552-r1" x="219.6" y="93.2" textLength="36.6" clip-path="url(#terminal-539408552-line-3)">&#160;|&#160;</text><text class="terminal-539408552-r4" x="256.2" y="93.2" textLength="73.2" clip-path="url(#terminal-539408552-line-3)">MODULE</text><text class="terminal-539408552-r1" x="329.4" y="93.2" textLength="12.2" clip-path="url(#terminal-539408552-line-3)">:</text><text class="terminal-539408552-r4" x="341.6" y="93.2" textLength="158.6" clip-path="url(#terminal-539408552-line-3)">CLICK_COMMAND</text><text class="terminal-539408552-r1" x="500.2" y="93.2" textLength="73.2" clip-path="url(#terminal-539408552-line-3)">]&#160;[--&#160;</text><text class="terminal-539408552-r4" x="573.4" y="93.2" textLength="134.2" clip-path="url(#terminal-539408552-line-3)">SCRIPT_ARGS</text><text class="terminal-539408552-r1" x="707.6" y="93.2" textLength="268.4" clip-path="url(#terminal-539408552-line-3)">...]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-539408552-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-539408552-line-3)">
+</text><text class="terminal-539408552-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-539408552-line-4)">
+</text><text class="terminal-539408552-r1" x="0" y="142" textLength="61" clip-path="url(#terminal-539408552-line-5)">&#160;The&#160;</text><text class="terminal-539408552-r1" x="61" y="142" textLength="122" clip-path="url(#terminal-539408552-line-5)">rich-click</text><text class="terminal-539408552-r1" x="183" y="142" textLength="695.4" clip-path="url(#terminal-539408552-line-5)">&#160;CLI&#160;provides&#160;attractive&#160;help&#160;output&#160;from&#160;any&#160;tool&#160;using&#160;</text><text class="terminal-539408552-r1" x="878.4" y="142" textLength="61" clip-path="url(#terminal-539408552-line-5)">click</text><text class="terminal-539408552-r1" x="939.4" y="142" textLength="36.6" clip-path="url(#terminal-539408552-line-5)">,&#160;&#160;</text><text class="terminal-539408552-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-539408552-line-5)">
+</text><text class="terminal-539408552-r1" x="0" y="166.4" textLength="195.2" clip-path="url(#terminal-539408552-line-6)">&#160;formatted&#160;with&#160;</text><text class="terminal-539408552-r1" x="195.2" y="166.4" textLength="48.8" clip-path="url(#terminal-539408552-line-6)">rich</text><text class="terminal-539408552-r1" x="244" y="166.4" textLength="732" clip-path="url(#terminal-539408552-line-6)">.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-539408552-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-539408552-line-6)">
+</text><text class="terminal-539408552-r5" x="12.2" y="190.8" textLength="927.2" clip-path="url(#terminal-539408552-line-7)">The&#160;rich-click&#160;command&#160;line&#160;tool&#160;can&#160;be&#160;prepended&#160;before&#160;any&#160;Python&#160;package&#160;</text><text class="terminal-539408552-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-539408552-line-7)">
+</text><text class="terminal-539408552-r5" x="12.2" y="215.2" textLength="841.8" clip-path="url(#terminal-539408552-line-8)">using&#160;native&#160;click&#160;to&#160;provide&#160;attractive&#160;richified&#160;click&#160;help&#160;output.</text><text class="terminal-539408552-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-539408552-line-8)">
+</text><text class="terminal-539408552-r5" x="12.2" y="239.6" textLength="512.4" clip-path="url(#terminal-539408552-line-9)">For&#160;example,&#160;if&#160;you&#160;have&#160;a&#160;package&#160;called&#160;</text><text class="terminal-539408552-r6" x="524.6" y="239.6" textLength="122" clip-path="url(#terminal-539408552-line-9)">my_package</text><text class="terminal-539408552-r5" x="646.6" y="239.6" textLength="317.2" clip-path="url(#terminal-539408552-line-9)">&#160;that&#160;uses&#160;click,&#160;you&#160;can&#160;</text><text class="terminal-539408552-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-539408552-line-9)">
+</text><text class="terminal-539408552-r5" x="12.2" y="264" textLength="48.8" clip-path="url(#terminal-539408552-line-10)">run:</text><text class="terminal-539408552-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-539408552-line-10)">
+</text><text class="terminal-539408552-r5" x="12.2" y="288.4" textLength="48.8" clip-path="url(#terminal-539408552-line-11)">&gt;&gt;&gt;&#160;</text><text class="terminal-539408552-r6" x="61" y="288.4" textLength="122" clip-path="url(#terminal-539408552-line-11)">rich-click</text><text class="terminal-539408552-r6" x="195.2" y="288.4" textLength="122" clip-path="url(#terminal-539408552-line-11)">my_package</text><text class="terminal-539408552-r6" x="329.4" y="288.4" textLength="73.2" clip-path="url(#terminal-539408552-line-11)">--help</text><text class="terminal-539408552-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-539408552-line-11)">
+</text><text class="terminal-539408552-r5" x="12.2" y="312.8" textLength="744.2" clip-path="url(#terminal-539408552-line-12)">This&#160;does&#160;not&#160;always&#160;work&#160;if&#160;the&#160;package&#160;is&#160;using&#160;customized&#160;</text><text class="terminal-539408552-r7" x="756.4" y="312.8" textLength="158.6" clip-path="url(#terminal-539408552-line-12)">click.group()</text><text class="terminal-539408552-r5" x="915" y="312.8" textLength="48.8" clip-path="url(#terminal-539408552-line-12)">&#160;or&#160;</text><text class="terminal-539408552-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-539408552-line-12)">
+</text><text class="terminal-539408552-r8" x="0" y="337.2" textLength="183" clip-path="url(#terminal-539408552-line-13)">[..truncated..]</text><text class="terminal-539408552-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-539408552-line-13)">
 </text>
     </g>
     </g>

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ glightbox: false
 - Rich is a _"Python library for rich text and beautiful formatting in the terminal"_.
 
 The intention of `rich-click` is to provide attractive help output from
-Click, formatted with Rich, with minimal customisation required.
+Click, formatted with Rich, with minimal customization required.
 
 ## Features
 
@@ -52,7 +52,7 @@ Click, formatted with Rich, with minimal customisation required.
 - 🎁 Group commands and options into named panels
 - ❌ Well formatted error messages
 - 🔢 Easily give custom sort order for options and commands
-- 🎨 Extensive customisation of styling and behaviour possible
+- 🎨 Extensive customization of styling and behaviour possible
 
 ## Installation
 
@@ -122,7 +122,7 @@ if __name__ == '__main__':
 
 ### More complex example
 
-**rich-click** has a ton of customisation options that let you compose help text however you'd like.
+**rich-click** has a ton of customization options that let you compose help text however you'd like.
 Below is a more complex example of what **rich-click** is capable of:
 
 ![](images/command_groups.svg){.screenshot}

--- a/docs/overrides/editor.html
+++ b/docs/overrides/editor.html
@@ -127,7 +127,7 @@
 <p>At the bottom of the page, there is generated code for the sample output.</p>
 
 <p><strong>The style options here are not exhaustive!</strong>
-There are many more ways to customise your <strong>rich-click</strong> outputs.
+There are many more ways to customize your <strong>rich-click</strong> outputs.
 Modern terminals also support more than the 8 colors used on this page; <a href="https://rich.readthedocs.io/en/stable/appendix/colors.html">see here for more information about terminal colors</a>.
 The Live Style Editor seeks to represent a useful subset of the available styling options.</p>
 <div class="container">

--- a/docs/overrides/editor.html
+++ b/docs/overrides/editor.html
@@ -127,7 +127,7 @@
 <p>At the bottom of the page, there is generated code for the sample output.</p>
 
 <p><strong>The style options here are not exhaustive!</strong>
-There are many more ways to customize your <strong>rich-click</strong> outputs.
+There are many more ways to customise your <strong>rich-click</strong> outputs.
 Modern terminals also support more than the 8 colors used on this page; <a href="https://rich.readthedocs.io/en/stable/appendix/colors.html">see here for more information about terminal colors</a>.
 The Live Style Editor seeks to represent a useful subset of the available styling options.</p>
 <div class="container">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,10 +42,12 @@ nav:
   - "Live Style Editor": editor.md
   - Documentation:
       - Introduction to Click: documentation/introduction_to_click.md
+      - "Comparison of Click & rich-click": documentation/comparison_of_click_and_rich_click.md
       - Configuration: documentation/configuration.md
       - "Formatting & Styles": documentation/formatting_and_styles.md
       - "Groups & Sorting": documentation/groups_and_sorting.md
       - "<code>rich-click</code> CLI tool": documentation/rich_click_cli.md
+      - Accessibility: documentation/accessibility.md
       # - API Reference: documentation/api_reference.md
   - Blog: blog/index.md
   - Changelog: changelog.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,8 @@ markdown_extensions:
       guess_lang: false
   - admonition
   - codehilite
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
   - extra
   - pymdownx.superfences:
       custom_fences:

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -3,7 +3,7 @@
 rich-click is a minimal Python module to combine the efforts of the excellent packages 'rich' and 'click'.
 
 The intention is to provide attractive help output from Click, formatted with Rich, with minimal
-customisation required.
+customization required.
 """
 
 __version__ = "1.8.5"

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -205,7 +205,7 @@ def main(
 
     >>> [command]rich-click[/] [argument]my_package[/] [option]--help[/]
 
-    This does not always work if the package is using customised [b]click.group()[/]
+    This does not always work if the package is using customized [b]click.group()[/]
     or [b]click.command()[/] classes.
     If in doubt, please suggest to the authors that they use rich_click within their
     tool natively - this will always give a better experience.

--- a/src/rich_click/decorators.py
+++ b/src/rich_click/decorators.py
@@ -159,14 +159,6 @@ def rich_config(
             stacklevel=2,
         )
         console = help_config
-    elif isinstance(help_config, Console):
-        import warnings
-
-        warnings.warn(
-            "We have no idea what just happened. Tread carefully.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
 
     if CLICK_IS_BEFORE_VERSION_8X:
 


### PR DESCRIPTION
WIP.

New pages:

- Comparison: https://dwreeves.github.io/rich-click/documentation/comparison_of_click_and_rich_click/
- Accessibility: https://dwreeves.github.io/rich-click/documentation/accessibility/

The comparison page is not only helpful but something we can point to in the future if users request e.g. that we add rich formatting to `echo()` and `echo_via_pager()`, since we do not intend on overwriting the Click implementations of these.

The accessibility page was discussed in another issue. I will link it in the issue rather than here because otherwise Github will auto-close the issue once this gets merged in.