### PR TITLE
Fix a couple of issues with click 8.2

### DIFF
--- a/src/rich_click/_compat_click.py
+++ b/src/rich_click/_compat_click.py
@@ -5,6 +5,7 @@ try:
     click_version = click.__version__
 except Exception:
     # Click 9+ deprecated __version__, so all these checks must necessarily be False if __version__ doesn't exist.
+    CLICK_IS_BEFORE_VERSION_82 = False
     CLICK_IS_BEFORE_VERSION_8X = False
     CLICK_IS_BEFORE_VERSION_9X = False
     CLICK_IS_VERSION_80 = False
@@ -12,6 +13,7 @@ else:
     _major = int(click_version.split(".")[0])
     _minor = int(click_version.split(".")[1])
 
+    CLICK_IS_BEFORE_VERSION_82 = (_major, _minor) < (8, 2)
     CLICK_IS_BEFORE_VERSION_8X = _major < 8
     CLICK_IS_BEFORE_VERSION_9X = _major < 9
     CLICK_IS_VERSION_80 = _major == 8 and _minor == 0

--- a/src/rich_click/rich_help_rendering.py
+++ b/src/rich_click/rich_help_rendering.py
@@ -22,7 +22,12 @@ from rich.table import Table
 from rich.text import Text
 from typing_extensions import Literal
 
-from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X, CLICK_IS_BEFORE_VERSION_9X, CLICK_IS_VERSION_80
+from rich_click._compat_click import (
+    CLICK_IS_BEFORE_VERSION_8X,
+    CLICK_IS_BEFORE_VERSION_9X,
+    CLICK_IS_BEFORE_VERSION_82,
+    CLICK_IS_VERSION_80,
+)
 from rich_click.rich_help_formatter import RichHelpFormatter
 from rich_click.utils import CommandGroupDict, OptionGroupDict
 
@@ -211,7 +216,7 @@ def _get_option_help(
 
     # Append metavar if requested
     if config.append_metavars_help:
-        metavar_str = param.make_metavar()
+        metavar_str = param.make_metavar() if CLICK_IS_BEFORE_VERSION_82 else param.make_metavar(ctx)  # type: ignore
         # Do it ourselves if this is a positional argument
         if isinstance(param, click.core.Argument) and re.match(rf"\[?{param.name.upper()}]?", metavar_str):
             metavar_str = param.type.name.upper()
@@ -497,7 +502,7 @@ def get_rich_options(
 
             # Column for a metavar, if we have one
             metavar = Text(style=formatter.config.style_metavar, overflow="fold")
-            metavar_str = param.make_metavar()
+            metavar_str = param.make_metavar() if CLICK_IS_BEFORE_VERSION_82 else param.make_metavar(ctx)  # type: ignore
 
             if TYPE_CHECKING:
                 assert isinstance(param.name, str)

--- a/tests/test_exit_code.py
+++ b/tests/test_exit_code.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from rich_click import RichContext, command, group, pass_context
-from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X
+from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_8X, CLICK_IS_BEFORE_VERSION_82
 
 
 # Don't use the 'invoke' fixture because we want control over the standalone_mode kwarg.
@@ -92,7 +92,7 @@ def test_group_return_value_does_not_raise_exit_code() -> None:
 
     runner = CliRunner()
     res = runner.invoke(cli, [])
-    assert res.exit_code == 0
+    assert res.exit_code == 0 if CLICK_IS_BEFORE_VERSION_82 else 2
 
 
 @pytest.mark.skipif(CLICK_IS_BEFORE_VERSION_8X, reason="Result does not have return_value attribute.")


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing and maintaining rich-click!

I am the maintainer of the Debian package of click; I uploaded click 8.2.0 to the Debian unstable suite a couple of days ago, and it turns out that might have been a bit premature, since there are a couple of incompatibilities that affect several other Python libraries. As noted in #223, rich-click is one of those - the click authors changed both the `make_metavar()` method and the behavior of a command-line program when run without specifying a required subcommand.

What do you think about these two changes that try to fix these problems?

Thanks in advance for your time, and keep up the great work!