### PR TITLE
Handful of small updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.8.8 (2025-03-09)
+
+- Make text wrap instead of using ellipses for overflowing metavars in options tables.
+- Added `--errors-in-output-format` flag to `rich-click` CLI.
+- Actually fixed regression in stderr handling [[#164](https://github.com/ewels/rich-click/issues/164)].
+
 ## Version 1.8.7 (2025-03-08)
 
 - Add ability to turn off option/command deduplication in groups [[#226](https://github.com/ewels/rich-click/issues/226)]

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -6,7 +6,7 @@ The intention is to provide attractive help output from Click, formatted with Ri
 customization required.
 """
 
-__version__ = "1.8.7"
+__version__ = "1.8.8"
 
 # Import the entire click API here.
 # We need to manually import these instead of `from click import *` to force

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -159,6 +159,13 @@ def _get_module_path_and_function_name(script: str, suppress_warnings: bool) -> 
     help="Optionally render help text as HTML or SVG. By default, help text is rendered normally.",
 )
 @click.option(
+    "--errors-in-output-format",
+    is_flag=True,
+    help="If set, forces the CLI to render CLI error messages"
+    " in the format specified by the --output option."
+    " By default, error messages render normally, i.e. they are not converted to html or svg.",
+)
+@click.option(
     "--suppress-warnings/--do-not-suppress-warnings",
     is_flag=True,
     default=False,
@@ -188,6 +195,7 @@ def main(
     ctx: RichContext,
     script_and_args: List[str],
     output: Literal[None, "html", "svg"],
+    errors_in_output_format: bool,
     suppress_warnings: bool,
     rich_config: Optional[RichHelpConfiguration],
     show_help: bool,
@@ -241,6 +249,8 @@ def main(
 
     if output is not None:
         RichContext.export_console_as = output
+        if errors_in_output_format:
+            RichContext.errors_in_output_format = True
 
     prog = module_path.split(".", 1)[0]
     sys.argv = [prog, *args]

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -2,6 +2,7 @@ import sys
 from typing import IO, TYPE_CHECKING, Any, Optional
 
 import click
+from typing_extensions import Literal
 
 from rich_click.rich_help_configuration import RichHelpConfiguration
 
@@ -68,6 +69,8 @@ class RichHelpFormatter(click.HelpFormatter):
     not be created directly
     """
 
+    export_console_as: Literal[None, "html", "svg"] = None
+
     def __init__(
         self,
         indent_increment: int = 2,
@@ -101,8 +104,8 @@ class RichHelpFormatter(click.HelpFormatter):
 
         if console:
             self.console = console
-            # if file:
-            #     self.console.file = file
+            if file:
+                self.console.file = file
         else:
             self.console = create_console(self.config, file=file)
 

--- a/src/rich_click/rich_help_rendering.py
+++ b/src/rich_click/rich_help_rendering.py
@@ -1,5 +1,6 @@
 import inspect
 import re
+import sys
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, TypeVar, Union, overload
 
@@ -605,6 +606,8 @@ def get_rich_options(
 
             kw.update(option_group.get("panel_styles", {}))
 
+            options_table.columns[0].overflow = "fold"
+
             formatter.write(Panel(options_table, **kw))
 
 
@@ -721,7 +724,9 @@ def get_rich_epilog(
         )
 
 
-def rich_format_error(self: click.ClickException, formatter: RichHelpFormatter) -> None:
+def rich_format_error(
+    self: click.ClickException, formatter: RichHelpFormatter, export_console_as: Literal[None, "html", "svg"] = None
+) -> None:
     """
     Print richly formatted click errors.
 
@@ -732,6 +737,7 @@ def rich_format_error(self: click.ClickException, formatter: RichHelpFormatter) 
     ----
         self (click.ClickException): Click exception to format.
         formatter: formatter object.
+        export_console_as: If set, outputs error message as HTML or SVG.
     """
     config = formatter.config
     # Print usage
@@ -798,6 +804,11 @@ def rich_format_error(self: click.ClickException, formatter: RichHelpFormatter) 
         )
     if config.errors_epilogue:
         formatter.write(Padding(config.errors_epilogue, (0, 1, 1, 1)))
+    if formatter.console.record:
+        if export_console_as == "html":
+            print(formatter.console.export_html(inline_styles=True, code_format="{code}"))
+        elif export_console_as == "svg":
+            print(formatter.console.export_svg(title="rich-click " + " ".join(sys.argv)))
 
 
 def rich_abort_error(formatter: RichHelpFormatter) -> None:


### PR DESCRIPTION
- Make text wrap instead of using ellipses for overflowing metavars in options tables.
- Added `--errors-in-output-format` flag to `rich-click` CLI.
- Actually fixed regression in stderr handling [[#164](https://github.com/ewels/rich-click/issues/164)].