### PR TITLE
Properly override `click.HelpFormatter.getvalue`

### DIFF
--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -140,3 +140,9 @@ class RichHelpFormatter(click.HelpFormatter):
     def write_abort(self) -> None:
         """Print richly formatted abort error."""
         self.console.print(self.config.aborted_text, style=self.config.style_aborted)
+
+    def getvalue(self) -> str:
+        if self.console.record:
+            return self.console.export_text()
+
+        return super().getvalue()

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -143,6 +143,6 @@ class RichHelpFormatter(click.HelpFormatter):
 
     def getvalue(self) -> str:
         if self.console.record:
-            return self.console.export_text()
+            return self.console.export_text(clear=False)
 
         return super().getvalue()

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -143,6 +143,6 @@ class RichHelpFormatter(click.HelpFormatter):
 
     def getvalue(self) -> str:
         if self.console.record:
-            return self.console.export_text(clear=False)
+            return self.console.export_text(clear=False, styles=True)
 
         return super().getvalue()


### PR DESCRIPTION
https://click.palletsprojects.com/en/stable/api/#click.HelpFormatter.getvalue

If the class attribute `export_console_as` on `RichContext` (or a subclass) is set to a value that is not `None` then getting the value of the buffer returns the raw text that was printed to the underlying console rather than returning an empty string from the parent class' method.

I'm a maintainer of https://github.com/mkdocs/mkdocs-click and I noticed that users of `rich-click` commands were not rendering the usage properly because [this line](https://github.com/mkdocs/mkdocs-click/blob/a614ab60b2f44ff5faa6d9c6554e6a857dacef5c/mkdocs_click/_docs.py#L196) was returning nothing. The choice to return text here is both out of necessity because the current context is inaccessible to that method and also because we happen to desire text so that rendering does not contain any formatting:

![image](https://github.com/user-attachments/assets/e19e5315-eb10-4874-a257-3dd995af9564)
