### PR TITLE
Remove Python 3.7 support and update CI

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,18 +18,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: astral-sh/setup-uv@v4
         with:
           python-version: 3.x
 
       - name: Install requirements for docs
         run: |
-          pip install -U uv
-          uv pip install --system --editable ".[docs]"
+          uv pip install --editable ".[docs]"
 
       - name: Generate terminal images with rich-codex
         uses: ewels/rich-codex@v1
         with:
+          use_uv: "true"
+          skip_python_setup: "true"
           commit_changes: "true"
           clean_img_paths: docs/images/*.svg
           skip_git_checks: "true"

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -5,16 +5,16 @@ on:
 
 jobs:
   build-n-publish:
+    if: github.repository == 'ewels/rich-click'
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check out source-code repository
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install python dependencies
         run: python -m pip install --upgrade pip setuptools wheel build
@@ -23,7 +23,6 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        if: github.repository == 'ewels/rich-click'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,11 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3
       - name: Install dependencies
         run: |
-          pip install -U uv
-          uv pip install --system --editable ".[dev]"
-      - uses: pre-commit/action@v2.0.3
+          pip install --editable ".[dev]"
+      - uses: pre-commit-ci/lite-action@v1.1.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,12 +5,10 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: [3.7, 3.12, 3.13]
+        python: [3.8, 3.12, 3.13]
         click: [7.0.*, 7.1.*, 8.0.*, 8.1.*]  # 8.2.*
         rich: [12.*, 13.*]
         exclude:
-#          - python: 3.7
-#            click: 8.2.*
           - python: 3.13
             click: 7.0.*
           - python: 3.13
@@ -20,27 +18,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python }}
 
       - name: Install dependencies
-        if: matrix.python != '3.7'
         run: |
-          pip install -U uv
-          uv pip install --system --editable ".[dev]"
-          uv pip install --system --upgrade "click==$CLICK_VERSION" --prerelease=allow
-          uv pip install --system --upgrade "rich==$RICH_VERSION" --prerelease=allow
-        env:
-          CLICK_VERSION: ${{ matrix.click }}
-          RICH_VERSION: ${{ matrix.rich }}
-
-      - name: Install dependencies (Python 3.7)
-        if: matrix.python == '3.7'
-        run: |
-          pip install --editable ".[dev]"
-          pip install --upgrade "click==$CLICK_VERSION"
-          pip install --upgrade "rich==$RICH_VERSION"
+          uv pip install --editable ".[dev]"
+          uv pip install --upgrade "click==$CLICK_VERSION" --prerelease=allow
+          uv pip install --upgrade "rich==$RICH_VERSION" --prerelease=allow
         env:
           CLICK_VERSION: ${{ matrix.click }}
           RICH_VERSION: ${{ matrix.rich }}

--- a/.github/workflows/rich-codex.yml
+++ b/.github/workflows/rich-codex.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   rich_codex:
-    if: github.repository_owner == 'ewels'
+    if: github.repository_owner == 'ewels' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: 3.x
 
@@ -24,6 +24,8 @@ jobs:
       - name: Generate terminal images with rich-codex
         uses: ewels/rich-codex@v1
         with:
+          use_uv: "true"
+          skip_python_setup: "true"
           commit_changes: "true"
           clean_img_paths: docs/images/*.svg
           terminal_width: 80

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -5,31 +5,21 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: [3.7, 3.11, 3.12]
+        python: [3.8, 3.12, 3.13]
         click: [7.0.*, 8.0.*, 8.1.*] # Skip click 7.1 since regression coverage is strictly higher in 7.0.
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python }}
 
       - name: Install dependencies
-        if: matrix.python != '3.7'
         run: |
-          pip install -U uv
-          uv pip install --system --editable "."
-          uv pip install --system --upgrade "click==$CLICK_VERSION"
-        env:
-          CLICK_VERSION: ${{ matrix.click }}
-
-      - name: Install dependencies (Python 3.7)
-        if: matrix.python == '3.7'
-        run: |
-          pip install --editable "."
-          pip install --upgrade "click==$CLICK_VERSION"
+          uv pip install --editable "."
+          uv pip install --upgrade "click==$CLICK_VERSION"
         env:
           CLICK_VERSION: ${{ matrix.click }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,25 +13,25 @@ repos:
 #      - id: prettier
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.27
+    rev: 03d0035246f3e81f36aed592ffb4bebf33a03106  # frozen: v1.7.7
     hooks:
       - id: actionlint
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.7.0
+    rev: 57b6ff7bf72affdd12c7f3fd6de761ba18a33b3a  # frozen: v2.5.1
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.7
+    rev: d119aaff6891558b6eaf52518386871d1d267131  # frozen: v0.11.6
     hooks:
       - id: ruff
-        name: Ruff - Linter
+        name: Ruff
         args: [--fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: a4920527036bb9a3f3e6055d595849d67d0da066  # frozen: 25.1.0
     hooks:
       - id: black
         language_version: python3.12
@@ -49,7 +49,7 @@ repos:
         require_serial: true
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: 63c8f8312b7559622c0d82815639671ae42132ac  # frozen: v2.4.1
     hooks:
     - id: codespell
       files: ^docs/.*\.md$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,36 +1,42 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools>=45",
+]
+
 [project]
 name = "rich-click"
 description = "Format click help output nicely with rich"
 readme = "README.md"
 license = { file = "LICENSE" }
-maintainers = [{ name = "Phil Ewels", email = "phil@ewels.co.uk" }, { name = "Daniel Reeves", email = "xdanielreeves@gmail.com"}]
-authors = [{ name = "Phil Ewels", email = "phil@ewels.co.uk" }]
-requires-python = ">=3.7"
+maintainers = [
+    { name = "Phil Ewels", email = "phil@ewels.co.uk" },
+    { name = "Daniel Reeves", email = "xdanielreeves@gmail.com" },
+]
+authors = [ { name = "Phil Ewels", email = "phil@ewels.co.uk" } ]
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dynamic = [
     "version",
 ]
 dependencies = [
     "click>=7",
-    'importlib-metadata; python_version < "3.8"',
     "rich>=10.7",
-    "typing_extensions>=4",
+    "typing-extensions>=4",
 ]
-[project.optional-dependencies]
-dev = [
+optional-dependencies.dev = [
     "mypy",
     "packaging",
     "pre-commit",
@@ -40,8 +46,8 @@ dev = [
     "ruff",
     "types-setuptools",
 ]
-docs = [
-    "markdown_include",
+optional-dependencies.docs = [
+    "markdown-include",
     "mkdocs",
     "mkdocs-glightbox",
     "mkdocs-material[imaging]~=9.5.18",
@@ -50,40 +56,41 @@ docs = [
     "mkdocstrings[python]",
     "rich-codex",
 ]
-[project.urls]
-Documentation = "https://github.com/ewels/rich-click"
-Homepage = "https://github.com/ewels/rich-click"
-Issues = "https://github.com/ewels/rich-click/issues"
-Repository = "https://github.com/ewels/rich-click"
-[project.scripts]
-rich-click = "rich_click.cli:main"
-
-[build-system]
-build-backend = "setuptools.build_meta"
-requires = [
-    "setuptools>=45",
-]
+urls.Documentation = "https://github.com/ewels/rich-click"
+urls.Homepage = "https://github.com/ewels/rich-click"
+urls.Issues = "https://github.com/ewels/rich-click/issues"
+urls.Repository = "https://github.com/ewels/rich-click"
+scripts.rich-click = "rich_click.cli:main"
 
 [tool.setuptools.dynamic]
 version = { attr = "rich_click.__version__" }
 
 [tool.black]
 line-length = 120
-target-version = ['py37']
+target-version = [ 'py37' ]
 
 [tool.ruff]
+line-length = 120
 exclude = [
     ".git",
-    "__pycache__",
     ".venv",
-    "venv",
+    "__pycache__",
     "build",
+    "docs/",
+    "examples/**",
     "sdist",
     "tests/fixtures/**",
-    "examples/**",
-    "docs/"
+    "venv",
 ]
-ignore = [
+
+lint.select = [
+    "D",    # pydocstyle
+    "E",    # pycodestyle
+    "F",    # flake8
+    "I001", # isort
+    "W",    # pycodestyle
+]
+lint.ignore = [
     "D100", # Missing docstring in public module
     "D102", # Missing docstring in public method
     "D105", # Missing docstring in magic method
@@ -92,41 +99,31 @@ ignore = [
     "D212", # Multi-line docstring summary should start at the first line
     "E731", # Do not assign a lambda expression, use a def
 ]
-line-length = 120
-select = [
-    "D",    # pydocstyle
-    "E",    # pycodestyle
-    "F",    # flake8
-    "W",    # pycodestyle
-    "I001", # isort
-]
-
-[tool.ruff.isort]
+lint.isort.known-first-party = [ "rich_click" ]
 # Todo:
 #   Add vertical hanging indent when supported.
 #   https://github.com/astral-sh/ruff/issues/2600
-lines-after-imports = 2
-known-first-party = ["rich_click"]
+lint.isort.lines-after-imports = 2
 
 [tool.pyproject-fmt]
 indent = 4
 
 [tool.pytest.ini_options]
 addopts = "-s -rP -vv --showlocals"
-pythonpath = ["tests", "src"]
-testpaths = ["tests"]
+pythonpath = [ "tests", "src" ]
+testpaths = [ "tests" ]
 
 [tool.mypy]
 python_version = "3.8"
 scripts_are_modules = true
 strict = true
 exclude = [
-    '.*?live_style_editor\.py$'
+    '.*?live_style_editor\.py$',
 ]
 
 [tool.pyright]
-include = ["src"]
-pythonVersion = "3.7"
+include = [ "src" ]
+pythonVersion = "3.8"
 typeCheckingMode = "basic"
 executionEnvironments = [
     { root = "src" },

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -34,9 +34,6 @@ def entry_points(*, group: str) -> "metadata.EntryPoints":  # type: ignore[name-
 
     epg = metadata.entry_points()
 
-    if sys.version_info < (3, 8) and hasattr(epg, "select"):
-        return epg.select(group=group)
-
     return epg.get(group, [])
 
 

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any, Dict, Optional
 
 import click
@@ -13,12 +14,6 @@ if TYPE_CHECKING:
     from rich.highlighter import Highlighter
 
 
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    cached_property = property
-
-
 def create_console(config: RichHelpConfiguration, file: Optional[IO[str]] = None) -> "Console":
     """
     Create a Rich Console configured from Rich Help Configuration.
@@ -28,6 +23,7 @@ def create_console(config: RichHelpConfiguration, file: Optional[IO[str]] = None
         config: Rich Help Configuration instance
         file: Optional IO stream to write Rich Console output
             Defaults to None.
+
     """
     from rich.console import Console
     from rich.theme import Theme
@@ -109,6 +105,7 @@ class RichHelpFormatter(click.HelpFormatter):
             export_console_as: How output is rendered by getvalue(). Default of None renders output normally.
             export_kwargs: Any kwargs passed to the export method of the Console in getvalue().
             **kwargs: Kwargs passed to click.HelpFormatter.
+
         """
         if config is not None:
             self.config = config


### PR DESCRIPTION
Python 3.7 has been end of life since 2023. I'm all for supporting old things (in fact, 3.8 is also end of life and is still supported!), but it has become a nuisance to support 3.7, notably since uv does not support Python 3.7 and I want to move all the CI to that.

So, starting in **rich-click** 1.9, I will be dropping support for Python 3.7.

I've also made some additional updates to the CI.

pre-commit revs are now frozen by their SHAs (`pre-commit autoupdate --freeze`).

I don't believe there is any such easy-to-use tool that does this for Github Actions other than Renovate, which is not set up. I don't believe actionlint does this for example. This is unfortunate given the `tj-actions/changed-files` issue last month.