### PR TITLE
Supress depreaction warning from click when accessing __version__

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,4 +15,4 @@ jobs:
         run: |
           pip install -U uv
           uv pip install --system --editable ".[dev]"
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.1

--- a/src/rich_click/_compat_click.py
+++ b/src/rich_click/_compat_click.py
@@ -1,8 +1,12 @@
+import warnings
+
 import click
 
 
 try:
-    click_version = click.__version__
+    with warnings.catch_warnings(module="click", category=DeprecationWarning, action="ignore"):
+        # Ignore deprecation warnings for click 8.0
+        click_version = click.__version__
 except Exception:
     # Click 9+ deprecated __version__, so all these checks must necessarily be False if __version__ doesn't exist.
     CLICK_IS_BEFORE_VERSION_82 = False

--- a/src/rich_click/_compat_click.py
+++ b/src/rich_click/_compat_click.py
@@ -4,8 +4,8 @@ import click
 
 
 try:
-    with warnings.catch_warnings(module="click", category=DeprecationWarning, action="ignore"):
-        # Ignore deprecation warnings for click 8.0
+    with warnings.catch_warnings():
+        warnings.simplefilter(category=DeprecationWarning, action="ignore")
         click_version = click.__version__
 except Exception:
     # Click 9+ deprecated __version__, so all these checks must necessarily be False if __version__ doesn't exist.


### PR DESCRIPTION
See https://github.com/ewels/rich-click/pull/238 for more context.