### PR TITLE
Ignore errors from type checker

### DIFF
--- a/src/rich_click/_compat_click.py
+++ b/src/rich_click/_compat_click.py
@@ -14,8 +14,8 @@ except Exception:
     CLICK_IS_BEFORE_VERSION_9X = False
     CLICK_IS_VERSION_80 = False
 else:
-    _major = int(click_version.split(".")[0])
-    _minor = int(click_version.split(".")[1])
+    _major = int(click_version.split(".")[0])  # type: ignore[attr-defined]
+    _minor = int(click_version.split(".")[1])  # type: ignore[attr-defined]
 
     CLICK_IS_BEFORE_VERSION_82 = (_major, _minor) < (8, 2)
     CLICK_IS_BEFORE_VERSION_8X = _major < 8

--- a/src/rich_click/patch.py
+++ b/src/rich_click/patch.py
@@ -21,11 +21,11 @@ class _PatchedRichMultiCommand(RichMultiCommand, _PatchedRichCommand):
     pass
 
 
-class _PatchedRichCommandCollection(RichCommandCollection, _PatchedRichCommand):
+class _PatchedRichCommandCollection(RichCommandCollection, _PatchedRichCommand):  # type: ignore[misc]
     pass
 
 
-class _PatchedRichGroup(RichGroup, _PatchedRichCommand):
+class _PatchedRichGroup(RichGroup, _PatchedRichCommand):  # type: ignore[misc]
     pass
 
 

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -152,9 +152,9 @@ class RichCommand(click.Command):
 
         # Process shell completion requests and exit early.
         if CLICK_IS_BEFORE_VERSION_8X:
-            from click.core import _bashcomplete  # type: ignore[attr-defined]
+            from click.core import _bashcomplete
 
-            _bashcomplete(self, prog_name, complete_var)
+            _bashcomplete(self, prog_name, complete_var)  # type: ignore[operator]
         else:
             self._main_shell_completion(extra, prog_name, complete_var)
 
@@ -277,11 +277,10 @@ if CLICK_IS_BEFORE_VERSION_9X:
         from click import MultiCommand
 
 else:
+    MultiCommand = Group
 
-    MultiCommand = Group  # type: ignore[misc,assignment]
 
-
-class RichMultiCommand(RichCommand, MultiCommand):
+class RichMultiCommand(RichCommand, MultiCommand):  # type: ignore[misc, valid-type]
     """
     Richly formatted click MultiCommand.
 
@@ -291,10 +290,10 @@ class RichMultiCommand(RichCommand, MultiCommand):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize RichMultiCommand class."""
-        MultiCommand.__init__(self, *args, **kwargs)
+        MultiCommand.__init__(self, *args, **kwargs)  # type: ignore[misc]
         self._register_rich_context_settings_from_callback()
 
-    def format_commands(self, ctx: RichContext, formatter: RichHelpFormatter) -> None:  # type: ignore[override]
+    def format_commands(self, ctx: RichContext, formatter: RichHelpFormatter) -> None:
         from rich_click.rich_help_rendering import get_rich_commands
 
         get_rich_commands(self, ctx, formatter)
@@ -316,7 +315,7 @@ class RichMultiCommand(RichCommand, MultiCommand):
             self.format_epilog(ctx, formatter)
 
 
-class RichGroup(RichMultiCommand, Group):
+class RichGroup(RichMultiCommand, Group):  # type: ignore[misc]
     """
     Richly formatted click Group.
 
@@ -378,7 +377,7 @@ class RichGroup(RichMultiCommand, Group):
         return super().__call__(*args, **kwargs)
 
 
-class RichCommandCollection(CommandCollection, RichGroup):
+class RichCommandCollection(CommandCollection, RichGroup):  # type: ignore[misc]
     """
     Richly formatted click CommandCollection.
 

--- a/src/rich_click/rich_help_rendering.py
+++ b/src/rich_click/rich_help_rendering.py
@@ -44,7 +44,7 @@ if CLICK_IS_BEFORE_VERSION_9X:
     # We need to load from here to help with patching.
     from rich_click.rich_command import MultiCommand  # type: ignore[attr-defined]
 else:
-    MultiCommand = Group  # type: ignore[misc,assignment]
+    MultiCommand = Group
 
 
 def _make_rich_rext(text: Union[str, Text], style: StyleType, formatter: RichHelpFormatter) -> Union[Markdown, Text]:
@@ -612,7 +612,7 @@ def get_rich_options(
 
 
 def get_rich_commands(
-    obj: MultiCommand,
+    obj: MultiCommand,  # type: ignore[valid-type]
     ctx: click.Context,
     formatter: RichHelpFormatter,
 ) -> None:
@@ -623,7 +623,7 @@ def get_rich_commands(
     # Look through COMMAND_GROUPS for this command
     # stick anything unmatched into a default group at the end
     cmd_groups = _resolve_groups(ctx=ctx, groups=formatter.config.command_groups, group_attribute="commands")
-    for command in obj.list_commands(ctx):
+    for command in obj.list_commands(ctx):  # type: ignore[attr-defined]
         for cmd_group in cmd_groups:
             if command in cmd_group.get("commands", []):
                 break
@@ -666,9 +666,9 @@ def get_rich_commands(
         )
         for command in cmd_group.get("commands", []):
             # Skip if command does not exist
-            if command not in obj.list_commands(ctx):
+            if command not in obj.list_commands(ctx):  # type: ignore[attr-defined]
                 continue
-            cmd = obj.get_command(ctx, command)
+            cmd = obj.get_command(ctx, command)  # type: ignore[attr-defined]
             if TYPE_CHECKING:
                 assert cmd is not None
             if cmd.hidden:
@@ -681,7 +681,6 @@ def get_rich_commands(
                 helptext = cmd.short_help or cmd.help or ""
             commands_table.add_row(command, _make_command_help(helptext, formatter, is_deprecated=cmd.deprecated))
         if commands_table.row_count > 0:
-
             kw: Dict[str, Any] = {
                 "border_style": formatter.config.style_commands_panel_border,
                 "title": cmd_group.get("name", formatter.config.commands_panel_title),
@@ -779,7 +778,6 @@ def rich_format_error(
     # attribute. Checking for the 'message' attribute works to make the
     # rich-click CLI compatible.
     if hasattr(self, "message"):
-
         kw: Dict[str, Any] = {}
 
         if isinstance(formatter.config.style_errors_panel_box, str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def expectations_dir(root_dir: Path) -> Path:
 
 @pytest.fixture
 def click_major_version() -> int:
-    return int(click.__version__.split(".")[0])
+    return int(click.__version__.split(".")[0])  # type: ignore[attr-defined]
 
 
 class AssertStr(Protocol):


### PR DESCRIPTION
Ignore errors from type checker to make pre-commit action pass, see https://github.com/ewels/rich-click/pull/239