### PR TITLE
Fix small bug in rich-click CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - `RichHelpFormatter` now defers printing by default if a user does not specify a Console. [[#231](https://github.com/ewels/rich-click/pull/231)] (With contributions from [@ofek](https://github.com/ofek))
 
+# Version 1.8.9 (2025-05-19)
+
+Click 8.2 support:
+
+- Fix deprecation warning in Click 8.2. [[#239](https://github.com/ewels/rich-click/pull/239)] ([@finsberg](https://github.com/finsberg))
+- Fix typing incompatibilities with Click 8.2. [[#240](https://github.com/ewels/rich-click/pull/240), [#242](https://github.com/ewels/rich-click/pull/242)] ([@finsberg](https://github.com/finsberg))
+- Fixed `no_args_is_help=True` with Click 8.2: [[#241](https://github.com/ewels/rich-click/issues/241)]
+- Added Click 8.2's support for `Parameter.deprecated: str | bool` [[#242](https://github.com/ewels/rich-click/pull/242)]
+
 ## Version 1.8.8 (2025-03-09)
 
 - Make text wrap instead of using ellipses for overflowing metavars in options tables.

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -98,6 +98,8 @@ def _get_module_path_and_function_name(script: str, suppress_warnings: bool) -> 
         if script == s.name:
             if not _selected:
                 module_path, function_name = s.value.split(":", 1)
+                if " [" in function_name and function_name.endswith("]"):
+                    function_name = function_name.split(" [")[0]
             if suppress_warnings:
                 break
             if s.value not in _selected:
@@ -119,7 +121,7 @@ def _get_module_path_and_function_name(script: str, suppress_warnings: bool) -> 
                 f"\n\nThe selected script is '{module_path}:{function_name}', which is being executed now."
                 "\n\nIt is safer and recommended that you specify the MODULE:CLICK_COMMAND"
                 f" ('{module_path}:{function_name}') instead of the script ('{script}'), like this:"
-                f"\n\n>>> rich-click {' '.join(_args)}"
+                f"\n\n>>> {' '.join(_args)}"
                 "\n\nAlternatively, you can pass --suppress-warnings to the rich-click CLI,"
                 " which will disable this message.",
                 fg="red",


### PR DESCRIPTION
- Fixed small bug in rich-click CLI
- Added CHANGELOG entry for 1.8.9 (forgot to do that).

I also noticed Typer does not work with the `rich-click` CLI. Not really a big deal at all honestly, as we do not officially support Typer, anyway, but it wouldn't be the worst thing to support just to not confuse users when it _sort of_ works, but ultimately doesn't. Two main issues arise:

- subcommands are not rendered for TyperGroups
- `--rich-config` does not work.