### PR TITLE
Feat: Added Rich Click Themes

### DIFF
--- a/examples/12_theme_simple.py
+++ b/examples/12_theme_simple.py
@@ -1,0 +1,72 @@
+import rich_click as click
+from rich_click import rich_config, RichHelpConfiguration
+from rich_click.rich_click_theme import RichClickTheme
+
+@rich_config(RichHelpConfiguration(theme=RichClickTheme.material))
+@click.group()
+@click.option(
+    "--debug/--no-debug",
+    "-d/-n",
+    default=False,
+    help="""Enable debug mode.
+    Newlines are removed by default.
+
+    Double newlines are preserved.""",
+)
+def cli(debug):
+    """
+    My amazing tool does all the things.
+
+    This is a minimal example based on documentation
+    from the 'click' package.
+
+    You can try using --help at the top level and also for
+    specific subcommands.
+    """
+    print(f"Debug mode is {'on' if debug else 'off'}")
+
+
+@cli.command()
+@click.option(
+    "--type",
+    required=True,
+    default="files",
+    show_default=True,
+    help="Type of file to sync",
+)
+@click.option("--all", is_flag=True)
+def sync(type, all):
+    """Synchronise all your files between two places.
+    Example command that doesn't do much except print to the terminal."""
+    print("Syncing")
+
+
+@cli.command(short_help="Optionally use short-help for the group help text")
+@click.option("--all", is_flag=True, help="Get everything")
+def download(all):
+    """
+    Pretend to download some files from
+    somewhere. Multi-line help strings are unwrapped
+    until you use a double newline.
+
+    Only the first paragraph is used in group help texts.
+    Don't forget you can opt-in to rich and markdown formatting!
+
+    \b
+    Click escape markers should still work.
+      * So you
+      * Can keep
+      * Your newlines
+
+    And this is a paragraph
+    that will be rewrapped again.
+
+    \f
+    Also if you want to write function help text that won't
+    be rendered to the terminal.
+    """
+    print("Downloading")
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/rich_click/rich_click_theme.py
+++ b/src/rich_click/rich_click_theme.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union
+from typing import Dict, Union
 
 
 class RichClickTheme(str, Enum):
@@ -22,7 +22,7 @@ class RichClickTheme(str, Enum):
 ThemeType = Union[RichClickTheme, "RichClickTheme"]
 
 
-THEMES: dict = {
+THEMES: Dict[str, Dict[str, str]] = {
     "default": {},
 
     "dracula": {

--- a/src/rich_click/rich_click_theme.py
+++ b/src/rich_click/rich_click_theme.py
@@ -1,0 +1,96 @@
+from enum import Enum
+from typing import Union
+
+class RichClickTheme(str, Enum):
+    """
+    Themes available for RichHelpConfiguration.
+    
+    Use a a Rich Click theme to quickly apply a predefined set of styles.
+    """
+
+    default = "default"         #: The default Rich Click theme.
+    dracula = "dracula"         #: Vibrant high-contract dark theme.
+    gruvbox = "gruvbox"         #: Warm and earthy color theme.
+    material = "material"       #: Google Material inspired theme.
+    monochrome = "monochrome"   #: Minimal grayscale theme.
+    nord = "nord"               #: Cool blues and soft color theme.
+    onedark = "onedark"         #: One Dark syntax based theme.
+    solarized = "solarized"     #: Solarized color theme.
+
+
+ThemeType = Union[RichClickTheme, "RichClickTheme"]
+
+
+THEMES: dict = {
+    "default": {},
+
+    "dracula": {
+        "style_option": "bold magenta",
+        "style_argument": "bold green",
+        "style_command": "bold cyan",
+        "style_switch": "bold red",
+        "style_usage": "bright_blue",
+        "style_deprecated": "bright_red",
+    },
+
+    "gruvbox": {
+        "style_option": "bold yellow",
+        "style_argument": "bold red",
+        "style_command": "bold bright_yellow",
+        "style_switch": "bright_black",
+        "style_usage": "bright_magenta",
+        "style_deprecated": "red",
+    },
+
+    "material": {
+        "style_option": "bold cyan",
+        "style_argument": "bold purple3",
+        "style_command": "bold light_sky_blue1",
+        "style_switch": "medium_purple3",
+        "style_usage": "bold sea_green3",
+        "style_deprecated": "bright_red",
+        "style_options_panel_border": "dim medium_purple3",
+        "style_commands_panel_border": "dim medium_purple3",
+        "style_helptext_first_line": "sea_green3",
+        "style_helptext": "dim sea_green3",
+        "style_commands_panel_box": "SQUARE",
+        "style_options_panel_box": "SQUARE",
+        "style_errors_panel_box": "SQUARE",
+    },
+
+    "monochrome": {
+        "style_option": "white",
+        "style_argument": "white",
+        "style_command": "white",
+        "style_switch": "white",
+        "style_usage": "dim",
+        "style_deprecated": "dim",
+    },
+
+    "nord": {
+        "style_option": "bold bright_cyan",
+        "style_argument": "bold white",
+        "style_command": "bold bright_blue",
+        "style_switch": "cyan",
+        "style_usage": "bright_white",
+        "style_deprecated": "bright_magenta",
+    },
+
+    "onedark": {
+        "style_option": "bold turquoise4",
+        "style_argument": "bold orange1",
+        "style_command": "bold blue",
+        "style_switch": "bold green",
+        "style_usage": "gray62",
+        "style_deprecated": "red",
+    },
+
+    "solarized": {
+        "style_option": "bold blue",
+        "style_argument": "bold green",
+        "style_command": "bold yellow",
+        "style_switch": "bold cyan",
+        "style_usage": "green",
+        "style_deprecated": "bright_red",
+    },
+}

--- a/src/rich_click/rich_click_theme.py
+++ b/src/rich_click/rich_click_theme.py
@@ -1,10 +1,11 @@
 from enum import Enum
 from typing import Union
 
+
 class RichClickTheme(str, Enum):
     """
     Themes available for RichHelpConfiguration.
-    
+
     Use a a Rich Click theme to quickly apply a predefined set of styles.
     """
 


### PR DESCRIPTION
Added a simple framework for adding new rich click themes within the rich click package as well as functionality to select the theme from the `@rich_config` decorator within the `RichHelpConfiguration` class.

Features:
- Easily add new themes by setting desired values in the `THEMES` nested dictionary.
- Theme selector is Enum for easy setup
- Theme framework still allows for detailed style overrides when set in the `@rich_config`

Disclamers:
- During pre-commit runs I received a SSL error trying to run `actionlint` (manually ran all others with passes for files modified in the PR)
- Took a stab at some predefined themes (I am not a designer). The themes themselves do not matter much as providing the framework for other users and contributors to easily create and add their own theme to be added into the package.
- Did not modify CHANGELOG or and docs but am happy to add anything necessary.