### PR TITLE
[WIP] Rich Parameters + Panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 Big changes:
 
-- TODO
+- `help=` is now a valid kwarg for `@argument()` decorator. See docs for more information.
 
 Small changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Big changes:
 Small changes:
 
 - "Deprecated" text properly handled and stylized in all places.
+- Improved `rich-click` CLI patching.
 
 Backend (mostly invisible) changes:
 

--- a/docs/documentation/comparison_of_click_and_rich_click.md
+++ b/docs/documentation/comparison_of_click_and_rich_click.md
@@ -11,13 +11,15 @@ Everything available via `#!python import click` is also available via `#!python
 
 The only things that **rich-click** explicitly overrides in the high-level API are the decorators:
 
-- `click.command()`
-- `click.group()`
+- `#!python click.command()`
+- `#!python click.group()`
+- `#!python click.option()` (+ its variants)
+- `#!python click.argument()`
 
-The only change to these decorators is that by default, their `cls=` parameters point to the **rich-click** implementations of `Command` (i.e. `RichCommand`) and `Group` (i.e. `RichGroup`).
+The only change to these decorators is that by default, their `#!python cls=` parameters point to the **rich-click** implementations.
 
 !!! note
-    There is also a thin wrapper around `pass_context()` to cast the `click.Context` type in the function signature to `click.RichContext` to assist with static type-checking with MyPy. Aside from different typing, there are no substantive changes to the `pass_context()` decorator.
+    There is also a thin wrapper around `#!python pass_context()` to cast the `#!python click.Context` type in the function signature to `#!python click.RichContext` to assist with static type-checking with MyPy. Aside from different typing, there are no substantive changes to the `#!python pass_context()` decorator.
 
 ## Click features that rich-click does _not_ override
 
@@ -56,12 +58,12 @@ This is a deliberate decision that we are unlikely to change in the future.
 We do not want to maintain a more spread-out API surface, and we encourage users to become comfortable using Rich directly; it's a great library and it's worth learning a little bit about it!
 If you'd like Rich markup for your echos and interactive elements, then you can:
 
-| Click Function | Rich Replacement | Rich Documentation |
-|---------------|------------------|---------------|
-| `click.echo()` | `rich.print()` | [Quick start](https://rich.readthedocs.io/en/stable/introduction.html#quick-start) |
-| `click.echo_via_pager()` | `rich.Console().pager()` | [Console](https://rich.readthedocs.io/en/stable/console.html#paging) |
-| `click.confirm()` | `rich.prompt.Confirm.ask()` | [Prompt](https://rich.readthedocs.io/en/stable/prompt.html) |
-| `click.prompt()` | `rich.prompt.Prompt.ask()` | [Prompt](https://rich.readthedocs.io/en/stable/prompt.html) |
+| Click Function                    | Rich Replacement                     | Rich Documentation |
+|-----------------------------------|--------------------------------------|---------------|
+| `#!python click.echo()`           | `#!python rich.print()`              | [Quick start](https://rich.readthedocs.io/en/stable/introduction.html#quick-start) |
+| `#!python click.echo_via_pager()` | `#!python rich.Console().pager()`    | [Console](https://rich.readthedocs.io/en/stable/console.html#paging) |
+| `#!python click.confirm()`        | `#!python rich.prompt.Confirm.ask()` | [Prompt](https://rich.readthedocs.io/en/stable/prompt.html) |
+| `#!python click.prompt()`         | `#!python rich.prompt.Prompt.ask()`  | [Prompt](https://rich.readthedocs.io/en/stable/prompt.html) |
 
 Below is a side-by-side comparison of Click and Rich implementations of echos and interactive elements in **rich-click**:
 

--- a/docs/documentation/rich_click_cli.md
+++ b/docs/documentation/rich_click_cli.md
@@ -92,6 +92,9 @@ _SVG and HTML generated from [`docs/code_snippets/rich_click_cli/app.py`](https:
 
 ## Notes on how the `rich-click` CLI works
 
+!!! note
+    The rest of this document contains technical details most users will not need to know.
+
 Under the hood, the `rich-click` CLI is patching the `click` module, and replacing the Click decorators and `click.Command`, `click.Group`, etc. objects with their equivalent **rich-click** versions.
 
 Sometimes, a subclassed `click.Command` will overwrite one of these methods:

--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -17,14 +17,8 @@ from click.core import Context as Context
 from click.core import Group as Group
 from click.core import Option as Option
 from click.core import Parameter as Parameter
-from click.decorators import argument as argument
-from click.decorators import confirmation_option as confirmation_option
-from click.decorators import help_option as help_option
 from click.decorators import make_pass_decorator as make_pass_decorator
-from click.decorators import option as option
 from click.decorators import pass_obj as pass_obj
-from click.decorators import password_option as password_option
-from click.decorators import version_option as version_option
 from click.exceptions import Abort as Abort
 from click.exceptions import BadArgumentUsage as BadArgumentUsage
 from click.exceptions import BadOptionUsage as BadOptionUsage
@@ -69,10 +63,16 @@ from click.utils import get_binary_stream as get_binary_stream
 from click.utils import get_text_stream as get_text_stream
 from click.utils import open_file as open_file
 
+from rich_click.decorators import argument as argument
 from rich_click.decorators import command as command
+from rich_click.decorators import confirmation_option as confirmation_option
 from rich_click.decorators import group as group
+from rich_click.decorators import help_option as help_option
+from rich_click.decorators import option as option
 from rich_click.decorators import pass_context as pass_context
+from rich_click.decorators import password_option as password_option
 from rich_click.decorators import rich_config as rich_config
+from rich_click.decorators import version_option as version_option
 from rich_click.rich_command import RichCommand as RichCommand
 from rich_click.rich_command import RichCommandCollection as RichCommandCollection
 from rich_click.rich_command import RichGroup as RichGroup

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -4,18 +4,15 @@ import os
 import sys
 from functools import wraps
 from gettext import gettext
-from importlib import import_module
+from importlib import (
+    import_module,
+    metadata,  # type: ignore[import,unused-ignore]
+)
 from typing import Any, List, Literal, Optional, Tuple, Union
-
-
-try:
-    from importlib import metadata  # type: ignore[import,unused-ignore]
-except ImportError:
-    # Python < 3.8
-    import importlib_metadata as metadata  # type: ignore[no-redef,import-not-found,unused-ignore]
 
 import click
 
+from rich_click.decorators import argument as _rich_argument
 from rich_click.decorators import command as _rich_command
 from rich_click.decorators import pass_context
 from rich_click.patch import patch as _patch
@@ -135,7 +132,15 @@ def _get_module_path_and_function_name(script: str, suppress_warnings: bool) -> 
 
 
 @_rich_command("rich-click", context_settings=dict(allow_interspersed_args=False, help_option_names=[]))
-@click.argument("script_and_args", nargs=-1, metavar="[SCRIPT | MODULE:CLICK_COMMAND] [-- SCRIPT_ARGS...]")
+@_rich_argument(
+    "script_and_args",
+    nargs=-1,
+    metavar="[SCRIPT | MODULE:CLICK_COMMAND] [-- SCRIPT_ARGS...]",
+    help="The script you want to run. If it's a Click CLI and you are rendering help text;"
+    " then the help text will render"
+    " [#FF6B6B bold]r[/][#FF8E53 bold]i[/][#FFB347 bold]c[/][#4ECDC4 bold]h[/]"
+    "[#45B7D1 bold]l[/][#74B9FF bold]y[/]. Otherwise, the script will run normally.",
+)
 @click.option(
     "--rich-config",
     "-c",
@@ -167,6 +172,12 @@ def _get_module_path_and_function_name(script: str, suppress_warnings: bool) -> 
     " (This option is hidden because this situation is extremely rare).",
 )
 @click.option(
+    "--patch-rich-click/--no-patch-rich-click",
+    is_flag=True,
+    default=True,
+    help="If set, patch [code]rich_click.Command[/code], not just [code]click.Command[/code].",
+)
+@click.option(
     # The rich-click CLI uses a special implementation of --help,
     # which is aware of the --rich-config object.
     "--help",
@@ -184,13 +195,19 @@ def main(
     output: Literal[None, "html", "svg"],
     errors_in_output_format: bool,
     suppress_warnings: bool,
+    patch_rich_click: bool,
     rich_config: Optional[RichHelpConfiguration],
     show_help: bool,
 ) -> None:
     """
-    The [link=https://github.com/ewels/rich-click]rich-click[/] CLI provides attractive help output from any
+    The [link=https://github.com/ewels/rich-click]rich-click[/] CLI provides
+    [#FF6B6B bold]r[/][#FF8E53 bold]i[/][#FFB347 bold]c[/][#4ECDC4 bold]h[/][#45B7D1 bold]l[/][#74B9FF bold]y[/]
+    formatted help output from any
     tool using [link=https://click.palletsprojects.com/]click[/], formatted with
     [link=https://github.com/Textualize/rich]rich[/].
+
+    Full docs here: [link=https://ewels.github.io/rich-click/latest/documentation/rich_click_cli/]\
+https://ewels.github.io/rich-click/latest/documentation/rich_click_cli/[/]
 
     The rich-click command line tool can be prepended before any Python package
     using native click to provide attractive richified click help output.
@@ -200,10 +217,10 @@ def main(
 
     >>> [command]rich-click[/] [argument]my_package[/] [option]--help[/]
 
-    This does not always work if the package is using customized [b]click.group()[/]
-    or [b]click.command()[/] classes.
-    If in doubt, please suggest to the authors that they use rich_click within their
-    tool natively - this will always give a better experience.
+    When not rendering help text, the provided command will run normally,
+    so it is safe to replace calls to the tool with [command]rich-click[/] in front, e.g.:
+
+    >>> [command]rich-click[/] [argument]my_package[/] [argument]cmd[/] [option]--foo[/] 3
     """  # noqa: D401
     if (show_help or not script_and_args) and not ctx.resilient_parsing:
         if rich_config is None:
@@ -212,12 +229,14 @@ def main(
             rich_config.use_markdown = False
             rich_config.use_rich_markup = True
             rich_config.text_markup = "rich"
+            if rich_config.show_arguments is None:
+                rich_config.show_arguments = False
         ctx.help_config = rich_config
         print(ctx.get_help())
         ctx.exit()
 
     # patch click before importing the program function
-    _patch(rich_config=rich_config)
+    _patch(rich_config=rich_config, patch_rich_click=patch_rich_click)
 
     script, *args = script_and_args
 

--- a/src/rich_click/decorators.py
+++ b/src/rich_click/decorators.py
@@ -2,14 +2,19 @@ import sys
 from gettext import gettext
 from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Optional, Type, TypeVar, Union, cast, overload
 
-from click import Command, Context, Group, Parameter
+from click import Argument, Command, Context, Group, Option, Parameter
+from click import argument as click_argument
 from click import command as click_command
+from click import confirmation_option as click_confirmation_option
 from click import option as click_option
 from click import pass_context as click_pass_context
+from click import password_option as click_password_option
+from click import version_option as click_version_option
 
 from rich_click.rich_command import RichCommand, RichGroup
 from rich_click.rich_context import RichContext
 from rich_click.rich_help_configuration import RichHelpConfiguration
+from rich_click.rich_parameters import RichArgument, RichOption
 
 from . import rich_click  # noqa: F401
 
@@ -236,3 +241,121 @@ def help_option(*param_decls: str, **kwargs: Any) -> Callable[[FC], FC]:
     kwargs.setdefault("callback", show_help)
 
     return click_option(*param_decls, **kwargs)
+
+
+def argument(*param_decls: str, cls: Optional[Type[Argument]] = None, **attrs: Any) -> Callable[[FC], FC]:
+    """
+    Attaches an argument to the command.  All positional arguments are
+    passed as parameter declarations to :class:`Argument`; all keyword
+    arguments are forwarded unchanged (except ``cls``).
+    This is equivalent to creating an :class:`Argument` instance manually
+    and attaching it to the :attr:`Command.params` list.
+
+    For the default argument class, refer to :class:`Argument` and
+    :class:`Parameter` for descriptions of parameters.
+
+    :param cls: the argument class to instantiate.  This defaults to
+                :class:`Argument`.
+    :param param_decls: Passed as positional arguments to the constructor of
+        ``cls``.
+    :param attrs: Passed as keyword arguments to the constructor of ``cls``.
+    """
+    if cls is None:
+        cls = RichArgument
+
+    return click_argument(*param_decls, cls=cls, **attrs)
+
+
+def option(*param_decls: str, cls: Optional[Type[Option]] = None, **attrs: Any) -> Callable[[FC], FC]:
+    """
+    Attaches an option to the command.  All positional arguments are
+    passed as parameter declarations to :class:`Option`; all keyword
+    arguments are forwarded unchanged (except ``cls``).
+    This is equivalent to creating an :class:`Option` instance manually
+    and attaching it to the :attr:`Command.params` list.
+
+    For the default option class, refer to :class:`Option` and
+    :class:`Parameter` for descriptions of parameters.
+
+    :param cls: the option class to instantiate.  This defaults to
+                :class:`Option`.
+    :param param_decls: Passed as positional arguments to the constructor of
+        ``cls``.
+    :param attrs: Passed as keyword arguments to the constructor of ``cls``.
+    """
+    if cls is None:
+        cls = RichOption
+
+    return click_option(*param_decls, cls=cls, **attrs)
+
+
+def confirmation_option(*param_decls: str, **kwargs: Any) -> Callable[[FC], FC]:
+    """
+    Add a ``--yes`` option which shows a prompt before continuing if
+    not passed. If the prompt is declined, the program will exit.
+
+    :param param_decls: One or more option names. Defaults to the single
+        value ``"--yes"``.
+    :param kwargs: Extra arguments are passed to :func:`option`.
+    """
+    kwargs.setdefault("cls", RichOption)
+    return click_confirmation_option(*param_decls, **kwargs)
+
+
+def password_option(*param_decls: str, **kwargs: Any) -> Callable[[FC], FC]:
+    """
+    Add a ``--password`` option which prompts for a password, hiding
+    input and asking to enter the value again for confirmation.
+
+    :param param_decls: One or more option names. Defaults to the single
+        value ``"--password"``.
+    :param kwargs: Extra arguments are passed to :func:`option`.
+    """
+    if not param_decls:
+        param_decls = ("--password",)
+
+    kwargs.setdefault("prompt", True)
+    kwargs.setdefault("confirmation_prompt", True)
+    kwargs.setdefault("hide_input", True)
+    return click_password_option(*param_decls, **kwargs)
+
+
+def version_option(
+    version: Optional[str] = None,
+    *param_decls: str,
+    package_name: Optional[str] = None,
+    prog_name: Optional[str] = None,
+    message: Optional[str] = None,
+    **kwargs: Any,
+) -> Callable[[FC], FC]:
+    """
+    Add a ``--version`` option which immediately prints the version
+    number and exits the program.
+
+    If ``version`` is not provided, Click will try to detect it using
+    :func:`importlib.metadata.version` to get the version for the
+    ``package_name``. On Python < 3.8, the ``importlib_metadata``
+    backport must be installed.
+
+    If ``package_name`` is not provided, Click will try to detect it by
+    inspecting the stack frames. This will be used to detect the
+    version, so it must match the name of the installed package.
+
+    :param version: The version number to show. If not provided, Click
+        will try to detect it.
+    :param param_decls: One or more option names. Defaults to the single
+        value ``"--version"``.
+    :param package_name: The package name to detect the version from. If
+        not provided, Click will try to detect it.
+    :param prog_name: The name of the CLI to show in the message. If not
+        provided, it will be detected from the command.
+    :param message: The message to show. The values ``%(prog)s``,
+        ``%(package)s``, and ``%(version)s`` are available. Defaults to
+        ``"%(prog)s, version %(version)s"``.
+    :param kwargs: Extra arguments are passed to :func:`option`.
+    :raise RuntimeError: ``version`` could not be detected.
+    """
+    kwargs.setdefault("cls", RichOption)
+    return click_version_option(
+        version, *param_decls, package_name=package_name, prog_name=prog_name, message=message, **kwargs
+    )

--- a/src/rich_click/patch.py
+++ b/src/rich_click/patch.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import click
 
+import rich_click
 import rich_click.rich_command
 from rich_click.decorators import command as _rich_command
 from rich_click.decorators import group as _rich_group
@@ -39,7 +40,7 @@ def rich_group(*args, **kwargs):  # type: ignore[no-untyped-def]
     return _rich_group(*args, **kwargs)
 
 
-def patch(rich_config: Optional[RichHelpConfiguration] = None) -> None:
+def patch(rich_config: Optional[RichHelpConfiguration] = None, patch_rich_click: bool = True) -> None:
     """Patch Click internals to use rich-click types."""
     from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_9X
 
@@ -51,5 +52,13 @@ def patch(rich_config: Optional[RichHelpConfiguration] = None) -> None:
     click.CommandCollection = _PatchedRichCommandCollection  # type: ignore[misc]
     if CLICK_IS_BEFORE_VERSION_9X:
         click.MultiCommand = _PatchedRichMultiCommand  # type: ignore[assignment,misc,unused-ignore]
+    if patch_rich_click:
+        rich_click.group = rich_group
+        rich_click.command = rich_command
+        rich_click.Group = _PatchedRichGroup  # type: ignore[misc]
+        rich_click.Command = _PatchedRichCommand  # type: ignore[misc]
+        rich_click.CommandCollection = _PatchedRichCommandCollection  # type: ignore[misc]
+        if CLICK_IS_BEFORE_VERSION_9X:
+            rich_click.MultiCommand = _PatchedRichMultiCommand  # type: ignore[assignment,misc,unused-ignore]
     if rich_config is not None:
         rich_config.dump_to_globals()

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -119,18 +119,16 @@ def __getattr__(name: str) -> Any:
 
         return RichHelpConfiguration.load_from_globals
     if name == "highlighter":
-        # TODO: Fix deprecation warning. For now, exclude.
+        import warnings
 
-        # import warnings
-
-        # warnings.warn(
-        #     "`highlighter` config option is deprecated."
-        #     " Please do one of the following instead: either set HIGHLIGHTER_PATTERNS = [...] if you want"
-        #     " to use regex; or for more advanced use cases where you'd like to use a different type"
-        #     " of rich.highlighter.Highlighter, subclass the `RichHelpFormatter` and update its `highlighter`.",
-        #     DeprecationWarning,
-        #     stacklevel=2,
-        # )
+        warnings.warn(
+            "`highlighter` config option is deprecated."
+            " Please do one of the following instead: either set HIGHLIGHTER_PATTERNS = [...] if you want"
+            " to use regex; or for more advanced use cases where you'd like to use a different type"
+            " of rich.highlighter.Highlighter, subclass the `RichHelpFormatter` and update its `highlighter`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         from rich_click.rich_help_configuration import OptionHighlighter
 

--- a/src/rich_click/rich_click.py
+++ b/src/rich_click/rich_click.py
@@ -90,7 +90,7 @@ ERRORS_EPILOGUE: Optional[Union[str, "rich.text.Text"]] = None
 ABORTED_TEXT: str = "Aborted."
 
 # Behaviours
-SHOW_ARGUMENTS: bool = False  # Show positional arguments
+SHOW_ARGUMENTS: Optional[bool] = None  # Show positional arguments
 SHOW_METAVARS_COLUMN: bool = True  # Show a column with the option metavar (eg. INTEGER)
 APPEND_METAVARS_HELP: bool = False  # Append metavar (eg. [TEXT]) after the help text
 GROUP_ARGUMENTS_OPTIONS: bool = False  # Show arguments with options instead of in own panel

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -65,6 +65,13 @@ class RichCommand(click.Command):
 
         See `rich_config` decorator for how to apply the settings.
         """
+        import warnings
+
+        warnings.warn(
+            "RichCommand.console is deprecated. Please use the click.Context's console instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.context_settings.get("rich_console")
 
     @property

--- a/src/rich_click/rich_help_configuration.py
+++ b/src/rich_click/rich_help_configuration.py
@@ -135,7 +135,7 @@ class RichHelpConfiguration:
     aborted_text: str = field(default="Aborted.")
 
     # Behaviours
-    show_arguments: bool = field(default=False)
+    show_arguments: Optional[bool] = field(default=None)
     """Show positional arguments"""
     show_metavars_column: bool = field(default=True)
     """Show a column with the option metavar (eg. INTEGER)"""

--- a/src/rich_click/rich_parameters.py
+++ b/src/rich_click/rich_parameters.py
@@ -1,0 +1,53 @@
+from typing import Any, Optional, Sequence
+
+import click
+
+
+class RichParameter(click.Parameter):
+    r"""
+    A parameter to a command comes in two versions: they are either
+    :class:`Option`\s or :class:`Argument`\s.  Other subclasses are currently
+    not supported by design as some of the internals for parsing are
+    intentionally not finalized.
+    """
+
+    def __init__(self, *args: Any, panel: Optional[str] = None, **kwargs: Any):
+        """Create RichParameter instance."""
+        super().__init__(*args, **kwargs)
+        self.panel = panel
+
+
+class RichArgument(click.Argument, RichParameter):
+    """
+    Arguments are positional parameters to a command.  They generally
+    provide fewer features than options but can have infinite ``nargs``
+    and are required by default.
+
+    All parameters are passed onwards to the constructor of :class:`Parameter`.
+    """
+
+    param_type_name = "argument"
+
+    def __init__(
+        self,
+        param_decls: Sequence[str],
+        required: Optional[bool] = None,
+        help: Optional[str] = None,
+        panel: Optional[str] = None,
+        **attrs: Any,
+    ) -> None:
+        """Create RichArgument instance."""
+        super().__init__(param_decls, required=required, **attrs)
+        self.help = help
+        self.panel = panel
+
+
+class RichOption(click.Option, RichParameter):
+    """
+    Options are usually optional values on the command line and
+    have some extra features that arguments don't have.
+
+    All other parameters are passed onwards to the parameter constructor.
+    """
+
+    pass

--- a/src/rich_click/utils.py
+++ b/src/rich_click/utils.py
@@ -30,9 +30,10 @@ def method_is_from_subclass_of(cls: Type[object], base_cls: Type[object], method
     This is used under the hood to see whether we would expect a patched RichCommand's help text
     methods to be compatible or incompatible with rich-click or not.
     """
-    return any(
-        getattr(c, method_name, None) == getattr(cls, method_name) for c in cls.__mro__ if issubclass(c, base_cls)
-    )
+    method = getattr(cls, method_name, None)
+    if method is None:
+        return False
+    return any(getattr(c, method_name, None) == method for c in cls.__mro__ if base_cls in c.__mro__)
 
 
 class CommandGroupDict(TypedDict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,6 @@ from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_82
 from rich_click.rich_command import RichCommand
 
 
-@pytest.fixture(autouse=True)
-def initialize_rich_click() -> None:
-    """Initialize `rich_click` module."""
-    # Isolate global configuration for each test.
-    reload(rc)
-
-
 re_link_ids = re.compile(r"id=[\d.\-]*?;.*?\x1b")
 
 
@@ -33,8 +26,12 @@ def replace_link_ids(render: str) -> str:
 
 
 @pytest.fixture(autouse=True)
-def default_config(initialize_rich_click: None) -> None:
-    # Default config settings from https://github.com/Textualize/rich/blob/master/tests/render.py
+def default_config() -> None:
+    # Isolate rich_click global config module for each test:
+    reload(rc)
+
+    # Default config settings
+    # from https://github.com/Textualize/rich/blob/master/tests/render.py
     rc.WIDTH = 100
     rc.COLOR_SYSTEM = None
     rc.FORCE_TERMINAL = True

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,89 @@
+from importlib import reload
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+import rich_click
+from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_9X
+
+
+@pytest.mark.skipif(not CLICK_IS_BEFORE_VERSION_9X, reason="Click 9 removes MultiCommand")
+def test_deprecation_warning_on_multi_command() -> None:
+    reload(rich_click)
+
+    with pytest.warns(DeprecationWarning):
+        from rich_click import RichMultiCommand  # noqa: F401
+
+
+def test_deprecation_warning_on_highlighter(cli_runner: CliRunner) -> None:
+    c = Console()
+
+    @rich_click.rich_config({})
+    @rich_click.pass_context
+    def cli(ctx: rich_click.RichContext) -> None:
+        if ctx.console is c:
+            print("OK!")
+        else:
+            print("ERROR!")
+
+    # console should be allowed to be first argument,
+    with pytest.warns(DeprecationWarning):
+        cli = rich_click.rich_config(c)(cli)  # type: ignore[arg-type]
+
+    cli = rich_click.command()(cli)
+
+    res = cli_runner.invoke(cli)
+    assert res.stdout == "OK!\n"
+
+
+def test_deprecation_cli_patch() -> None:
+
+    with patch("rich_click.cli._patch") as mock_underlying_patch:
+        with pytest.warns(DeprecationWarning, match=r"`rich_click\.cli\.patch\(\)` has moved.*"):
+            import rich_click.cli
+
+            rich_click.cli.patch(a=1, b=2)
+
+    mock_underlying_patch.assert_called_once_with(a=1, b=2)
+
+
+def test_deprecation_command_help_config() -> None:
+
+    @rich_click.command()
+    def cli1() -> None:
+        pass
+
+    with pytest.warns(DeprecationWarning):
+        cfg1 = getattr(cli1, "help_config")
+    assert cfg1 is None
+
+    @rich_click.command()
+    @rich_click.rich_config({})
+    def cli2() -> None:
+        pass
+
+    with pytest.warns(DeprecationWarning):
+        cfg2 = getattr(cli2, "help_config")
+    assert isinstance(cfg2, rich_click.RichHelpConfiguration)
+
+
+def test_deprecation_command_console() -> None:
+
+    @rich_click.command()
+    def cli1() -> None:
+        pass
+
+    with pytest.warns(DeprecationWarning):
+        con1 = getattr(cli1, "console")
+    assert con1 is None
+
+    @rich_click.command()
+    @rich_click.rich_config(console=Console())
+    def cli2() -> None:
+        pass
+
+    with pytest.warns(DeprecationWarning):
+        con2 = getattr(cli2, "console")
+    assert isinstance(con2, Console)

--- a/tests/test_exit_code.py
+++ b/tests/test_exit_code.py
@@ -7,9 +7,6 @@ from rich_click import RichContext, command, group, pass_context
 from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_82
 
 
-# Don't use the 'invoke' fixture because we want control over the standalone_mode kwarg.
-
-
 def test_command_exit_code_with_context() -> None:
     for expected_exit_code in range(10):
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,37 @@
+import pytest
+from click import Abort
+from click.testing import CliRunner
+from inline_snapshot import snapshot
+
+import rich_click
+import rich_click.rich_click as rc
+from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_82
+from rich_click.utils import truthy
+
+
+@pytest.mark.skipif(CLICK_IS_BEFORE_VERSION_82, reason="CliRunner's stderr capture doesn't work before 8.2.")
+def test_abort(cli_runner: CliRunner) -> None:
+    rc.COLOR_SYSTEM = "truecolor"
+
+    @rich_click.command
+    def cli() -> None:
+        raise Abort()
+
+    res = cli_runner.invoke(cli)
+
+    assert res.stdout == snapshot("")
+    assert res.stderr == snapshot(
+        """\
+\x1b[31mAborted.\x1b[0m
+"""
+    )
+
+
+def test_truthy() -> None:
+    assert truthy("true") is True
+    assert truthy("1") is True
+    assert truthy("false") is False
+    assert truthy("0") is False
+    assert truthy(None) is None
+    assert truthy(10) is True
+    assert truthy("a") is None

--- a/tests/test_rich_click_cli.py
+++ b/tests/test_rich_click_cli.py
@@ -1,33 +1,43 @@
-# ruff: noqa: D101,D103,D401
+# ruff: noqa: D101,D103,D401,E501
+import json
 import os
 import subprocess
 import sys
+from importlib.metadata import version
 from inspect import cleandoc
 from pathlib import Path
-from typing import Callable, List, Protocol
+from typing import Callable, Dict, List, Optional, Protocol
 
+import packaging.version
 import pytest
 from click.testing import CliRunner
 from inline_snapshot import snapshot
 from pytest import MonkeyPatch
 
-import rich_click.rich_click as rc
 from rich_click.cli import main
 from rich_click.rich_context import RichContext
-
-
-@pytest.fixture(autouse=True)
-def default_config(initialize_rich_click: None) -> None:
-    # Default config settings from https://github.com/Textualize/rich/blob/master/tests/render.py
-    rc.WIDTH = 100
-    rc.COLOR_SYSTEM = None
-    rc.FORCE_TERMINAL = True
 
 
 class WriteScript(Protocol):
     def __call__(self, script: str, module_name: str = "mymodule.py") -> Path:
         """Write a script to a directory."""
         ...
+
+
+def run_as_subprocess(args: List[str], env: Optional[Dict[str, str]] = None) -> "subprocess.CompletedProcess[bytes]":
+    # Throughout most of this test module,
+    # to avoid side effects and to test and uncover potential issues with lazy-loading,
+    # we need to use subprocess.run() instead of cli_runner.invoke().
+
+    _env = {**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"}
+    _env.update(env or {})
+    res = subprocess.run(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_env,
+    )
+    return res
 
 
 @pytest.fixture
@@ -72,12 +82,7 @@ def simple_script(mock_script_writer: WriteScript) -> Path:
     ],
 )
 def test_simple_rich_click_cli(simple_script: Path, command: List[str]) -> None:
-    res = subprocess.run(
-        [sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False", "NO_COLOR": "1"},
-    )
+    res = run_as_subprocess([sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"])
     assert res.returncode == 0
     assert res.stdout.decode() == snapshot(
         """\
@@ -107,68 +112,90 @@ def test_simple_rich_click_cli_execute_command(simple_script: Path, cli_runner: 
     assert res.exit_code == 0
     assert res.stdout == "Hello, world!\n"
 
-    # Throughout the rest of this test module,
-    # to avoid side effects and to test and uncover potential issues with lazy-loading,
-    # we need to use subprocess.run() instead of cli_runner.invoke().
-
-    subprocess_res = subprocess.run(
-        [sys.executable, "-m", "src.rich_click", *command],
-        stdout=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
-    )
+    subprocess_res = run_as_subprocess([sys.executable, "-m", "src.rich_click", *command])
     assert subprocess_res.returncode == 0
 
     assert subprocess_res.stdout.decode() == "Hello, world!\n"
 
 
 def test_rich_click_cli_help() -> None:
-    res = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "src.rich_click",
-            "--help",
-        ],
-        stdout=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
-    )
+    res = run_as_subprocess([sys.executable, "-m", "src.rich_click", "--help"])
     assert res.returncode == 0
 
 
 def test_rich_click_cli_help_with_rich_config() -> None:
-    res = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "src.rich_click",
-            "--rich-config",
-            '{"style_option": "bold red"}',
-            "--help",
-        ],
-        stdout=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "--rich-config", '{"style_option": "bold red"}', "--help"]
     )
     assert res.returncode == 0
 
 
+def test_rich_click_cli_help_with_rich_config_from_file(tmp_path: Path) -> None:
+    config_data = {"options_panel_title": "Custom Name"}
+    config_file = tmp_path / "myconfig.json"
+    config_file.write_text(json.dumps(config_data))
+
+    res = run_as_subprocess([sys.executable, "-m", "src.rich_click", "--rich-config", f"@{config_file}", "--help"])
+    assert res.returncode == 0
+    assert res.stdout.decode() == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: python -m src.rich_click [OPTIONS] [SCRIPT | MODULE:CLICK_COMMAND] [-- SCRIPT_ARGS...]      \n\
+                                                                                                    \n\
+ The rich-click CLI provides richly formatted help output from any tool using click, formatted with \n\
+ rich.                                                                                              \n\
+ Full docs here: https://ewels.github.io/rich-click/latest/documentation/rich_click_cli/            \n\
+ The rich-click command line tool can be prepended before any Python package using native click to  \n\
+ provide attractive richified click help output.                                                    \n\
+ For example, if you have a package called my_package that uses click, you can run:                 \n\
+ >>> rich-click my_package --help                                                                   \n\
+ When not rendering help text, the provided command will run normally, so it is safe to replace     \n\
+ calls to the tool with rich-click in front, e.g.:                                                  \n\
+ >>> rich-click my_package cmd --foo 3                                                              \n\
+                                                                                                    \n\
+╭─ Custom Name ────────────────────────────────────────────────────────────────────────────────────╮
+│ --rich-config                         -c  JSON             Keyword arguments to pass into the    │
+│                                                            RichHelpConfiguration() used to       │
+│                                                            render the help text of the command.  │
+│                                                            You can pass either a JSON directly,  │
+│                                                            or a file prefixed with `@` (for      │
+│                                                            example: '@rich_config.json'). Note   │
+│                                                            that the --rich-config option is also │
+│                                                            used to render this help text you're  │
+│                                                            reading right now!                    │
+│ --output                              -o  [html|svg|text]  Optionally render help text as HTML   │
+│                                                            or SVG or plain text. By default,     │
+│                                                            help text is rendered normally.       │
+│ --errors-in-output-format                                  If set, forces the CLI to render CLI  │
+│                                                            error messages in the format          │
+│                                                            specified by the --output option. By  │
+│                                                            default, error messages render        │
+│                                                            normally, i.e. they are not converted │
+│                                                            to html or svg.                       │
+│ --patch-rich-click/--no-patch-rich-c                       If set, patch rich_click.Command, not │
+│ lick                                                       just click.Command.                   │
+│ --help                                -h                   Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+    )
+
+
 def test_rich_click_cli_help_with_bad_rich_config() -> None:
-    res = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "src.rich_click",
-            "--rich-config",
-            '{"bad", "json"}',
-            "--help",
-        ],
-        stdout=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "--rich-config", '{"bad", "json"}', "--help"],
+    )
+    assert res.returncode == 0
+
+
+def test_rich_click_cli_help_with_bad_rich_config_v2() -> None:
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "--rich-config", "[]", "--help"],
     )
     assert res.returncode == 0
 
 
 def test_custom_config_rich_click_cli(simple_script: Path) -> None:
-    res = subprocess.run(
+    res = run_as_subprocess(
         [
             sys.executable,
             "-m",
@@ -177,9 +204,7 @@ def test_custom_config_rich_click_cli(simple_script: Path) -> None:
             '{"options_panel_title": "Custom Name"}',
             "mymodule:cli",
             "--help",
-        ],
-        stdout=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
+        ]
     )
     assert res.returncode == 0
     assert res.stdout.decode() == snapshot(
@@ -218,10 +243,8 @@ def test_override_click_command(mock_script_writer: Callable[[str], Path]) -> No
         ''',
     )
 
-    res = subprocess.run(
+    res = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"],
-        stdout=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
     )
     assert res.returncode == 0
 
@@ -269,10 +292,8 @@ def test_override_click_group(mock_script_writer: Callable[[str], Path]) -> None
         ''',
     )
 
-    res = subprocess.run(
+    res = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"],
-        stdout=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
     )
     assert res.returncode == 0
 
@@ -301,26 +322,13 @@ def test_override_rich_click_command(mock_script_writer: WriteScript) -> None:
         # Test if robust to subclassing
         class OverrideRichCommand(click.RichCommand):
             def format_usage(self, ctx, formatter):
-                formatter.write('I am overriding RichCommand!')
+                formatter.write('I am overriding RichCommand! (usage)')
             def format_help_text(self, ctx, formatter):
-                formatter.write('I am overriding RichCommand!')
+                formatter.write('I am overriding RichCommand! (help_text)')
             def format_options(self, ctx, formatter):
-                formatter.write('I am overriding RichCommand!')
+                formatter.write('I am overriding RichCommand! (options)')
             def format_epilog(self, ctx, formatter):
-                formatter.write('I am overriding RichCommand!')
-
-        class OverrideRichGroup(OverrideRichCommand, click.RichGroup):
-            command_class = OverrideRichCommand
-            def format_commands(self, ctx, formatter):
-                formatter.write('I am overriding RichCommand!')
-
-        @click.group(cls=OverrideRichGroup)
-        def cli():
-            """My help text"""
-
-        @cli.command("subcommand")
-        def subcommand():
-            """Subcommand help text"""
+                formatter.write('I am overriding RichCommand! (epilog)')
 
         @click.command(cls=OverrideRichCommand)
         def cli():
@@ -329,15 +337,18 @@ def test_override_rich_click_command(mock_script_writer: WriteScript) -> None:
         '''
     )
 
-    res = subprocess.run(
-        [sys.executable, "-m", "rich_click", "mymodule:cli", "--help"], stdout=subprocess.PIPE, env=os.environ
+    res = run_as_subprocess([sys.executable, "-m", "rich_click", "mymodule:cli", "--help"])
+    assert res.returncode == 0
+
+    assert res.returncode == 0
+    assert res.stdout.decode() == snapshot(
+        """\
+I am overriding RichCommand! (usage)
+I am overriding RichCommand! (help_text)
+I am overriding RichCommand! (options)
+I am overriding RichCommand! (epilog)
+"""
     )
-    assert res.returncode == 0
-
-    expected_output = "I am overriding RichCommand!\n" * 4
-
-    assert res.returncode == 0
-    assert res.stdout.decode() == expected_output
 
 
 def test_override_rich_click_group(mock_script_writer: Callable[[str], Path]) -> None:
@@ -348,11 +359,13 @@ def test_override_rich_click_group(mock_script_writer: Callable[[str], Path]) ->
         # Test if robust to subclassing
         class OverrideRichCommand(click.RichCommand):
             def format_usage(self, ctx, formatter):
-                formatter.write('I am overriding RichCommand!')
+                formatter.write('I am overriding RichCommand! (usage)')
             def format_help_text(self, ctx, formatter):
-                formatter.write('I am overriding RichCommand!')
+                formatter.write('I am overriding RichCommand! (help_text)')
+            def format_options(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (options)')
             def format_epilog(self, ctx, formatter):
-                formatter.write('I am overriding RichCommand!')
+                formatter.write('I am overriding RichCommand! (epilog)')
 
         class OverrideRichGroup(OverrideRichCommand, click.RichGroup):
             command_class = OverrideRichCommand
@@ -362,33 +375,236 @@ def test_override_rich_click_group(mock_script_writer: Callable[[str], Path]) ->
         @click.group(cls=OverrideRichGroup)
         def cli():
             """My help text"""
-
-        @cli.command("subcommand")
-        def subcommand():
-            """Subcommand help text"""
-
-        @click.command(cls=OverrideRichCommand)
-        def cli():
-            """My help text"""
-            print('Hello, world!')
         ''',
     )
 
-    res = subprocess.run(
+    res = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"],
-        stdout=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
     )
     assert res.returncode == 0
 
     assert res.stdout.decode() == snapshot(
         """\
-I am overriding RichCommand!
-I am overriding RichCommand!
+I am overriding RichCommand! (usage)
+I am overriding RichCommand! (help_text)
+I am overriding RichCommand! (options)
+I am overriding RichCommand! (epilog)
+"""
+    )
+
+
+def test_override_rich_click_command_collection(mock_script_writer: Callable[[str], Path]) -> None:
+    mock_script_writer(
+        '''
+        import rich_click as click
+
+        # Test if robust to subclassing
+        class OverrideRichCommand(click.RichCommand):
+            def format_usage(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (usage)')
+            def format_help_text(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (help_text)')
+            def format_options(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (options)')
+            def format_epilog(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (epilog)')
+
+        class OverrideRichCommandCollection(OverrideRichCommand, click.RichCommandCollection):
+            command_class = OverrideRichCommand
+            def format_commands(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand (format_commands)!')
+
+        @click.group(cls=OverrideRichCommandCollection)
+        def cli():
+            """My help text"""
+
+        @cli.command("subcommand")
+        def subcommand():
+            """Subcommand help text"""
+        ''',
+    )
+
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"],
+    )
+    assert res.returncode == 0
+
+    assert res.stdout.decode() == snapshot(
+        """\
+I am overriding RichCommand! (usage)
+I am overriding RichCommand! (help_text)
+I am overriding RichCommand! (options)
+I am overriding RichCommand! (epilog)
+"""
+    )
+
+
+def test_override_guard_click_command(mock_script_writer: Callable[[str], Path]) -> None:
+    mock_script_writer(
+        '''
+        import click
+
+        # Test if robust to subclassing
+        class OverrideCommand(click.Command):
+            def format_usage(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (usage)')
+            def format_help_text(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (help_text)')
+            def format_options(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (options)')
+            def format_epilog(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (epilog)')
+
+        @click.group(cls=OverrideCommand)
+        def cli():
+            """My help text"""
+        ''',
+    )
+
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"],
+    )
+    assert res.returncode == 0
+
+    assert res.stdout.decode() == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: python -m src.rich_click.mymodule [OPTIONS]                                                 \n\
+                                                                                                    \n\
+ My help text                                                                                       \n\
+                                                                                                    \n\
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help      Show this message and exit.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-I am overriding RichCommand!
+"""
+    )
+
+
+def test_override_guard_click_group(mock_script_writer: Callable[[str], Path]) -> None:
+    mock_script_writer(
+        '''
+        import click
+
+        # Test if robust to subclassing
+        class OverrideCommand(click.Command):
+            def format_usage(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (usage)')
+            def format_help_text(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (help_text)')
+            def format_options(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (options)')
+            def format_epilog(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (epilog)')
+
+        class OverrideGroup(OverrideCommand, click.Group):
+            command_class = OverrideCommand
+            def format_commands(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand (format_commands)!')
+
+        @click.group(cls=OverrideGroup)
+        def cli():
+            """My help text"""
+        ''',
+    )
+
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"],
+    )
+    assert res.returncode == 0
+
+    assert res.stdout.decode() == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
+                                                                                                    \n\
+ My help text                                                                                       \n\
+                                                                                                    \n\
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+    )
+
+
+def test_override_guard_disabled_click_from_rich_click(mock_script_writer: Callable[[str], Path]) -> None:
+    mock_script_writer(
+        '''
+        import rich_click as click
+
+        # Test if robust to subclassing
+        class OverrideCommand(click.Command):
+            def format_usage(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (usage)')
+            def format_help_text(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (help_text)')
+            def format_options(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (options)')
+            def format_epilog(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (epilog)')
+
+        class OverrideGroup(OverrideCommand, click.Group):
+            command_class = OverrideCommand
+            def format_commands(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand (format_commands)!')
+
+        @click.group(cls=OverrideGroup)
+        def cli():
+            """My help text"""
+        ''',
+    )
+
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "--no-patch-rich-click", "mymodule:cli", "--help"],
+    )
+    assert res.returncode == 0
+
+    assert res.stdout.decode() == snapshot(
+        "I am overriding RichCommand! (usage)I am overriding RichCommand! (help_text)I am overriding RichCommand! (options)I am overriding RichCommand! (epilog)\n"
+    )
+
+
+def test_override_guard_enabled_click_from_rich_click(mock_script_writer: Callable[[str], Path]) -> None:
+    mock_script_writer(
+        '''
+        import rich_click as click
+
+        # Test if robust to subclassing
+        class OverrideCommand(click.Command):
+            def format_usage(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (usage)')
+            def format_help_text(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (help_text)')
+            def format_options(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (options)')
+            def format_epilog(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand! (epilog)')
+
+        class OverrideGroup(OverrideCommand, click.Group):
+            command_class = OverrideCommand
+            def format_commands(self, ctx, formatter):
+                formatter.write('I am overriding RichCommand (format_commands)!')
+
+        @click.group(cls=OverrideGroup)
+        def cli():
+            """My help text"""
+        ''',
+    )
+
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"],
+    )
+    assert res.returncode == 0
+
+    assert res.stdout.decode() == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
+                                                                                                    \n\
+ My help text                                                                                       \n\
+                                                                                                    \n\
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )
 
@@ -408,11 +624,8 @@ def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
         '''
     )
 
-    res_grp = subprocess.run(
+    res_grp = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:foo", "--bad-input"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
     )
     assert res_grp.returncode == 2
     assert res_grp.stdout.decode() == ""
@@ -429,11 +642,8 @@ def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
 """
     )
 
-    res_cmd = subprocess.run(
+    res_cmd = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:foo", "bar", "--bad-input"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env={**os.environ, "TERMINAL_WIDTH": "100", "FORCE_COLOR": "False"},
     )
     assert res_cmd.returncode == 2
 
@@ -448,5 +658,202 @@ def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
 │ No such option: --bad-input                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                     \n\
+"""
+    )
+
+
+rich_version = packaging.version.parse(version("rich"))
+
+
+@pytest.mark.skipif(rich_version < packaging.version.parse("13.0.0"), reason="Rich <13 renders differently")
+def test_cli_output_html(mock_script_writer: Callable[[str], Path]) -> None:
+    mock_script_writer(
+        '''
+        import rich_click as click
+
+        @click.command()
+        def cli():
+            """My help text"""
+        ''',
+    )
+
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "--output", "html", "mymodule:cli", "--help"],
+    )
+    assert res.returncode == 0
+
+    assert res.stdout.decode() == snapshot(
+        """\
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.r1 {color: #808000; text-decoration-color: #808000}
+.r2 {font-weight: bold}
+.r3 {color: #008080; text-decoration-color: #008080; font-weight: bold}
+.r4 {color: #7f7f7f; text-decoration-color: #7f7f7f}
+body {
+    color: #000000;
+    background-color: #ffffff;
+}
+</style>
+</head>
+<body>
+    <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><code style="font-family:inherit">                                                                                                    \n\
+ <span class="r1">Usage:</span> <span class="r2">python -m src.rich_click.mymodule</span> [<span class="r3">OPTIONS</span>]                                                 \n\
+                                                                                                    \n\
+ My help text                                                                                       \n\
+                                                                                                    \n\
+<span class="r4">╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮</span>
+<span class="r4">│</span> <span class="r3">--help</span>      Show this message and exit.                                                          <span class="r4">│</span>
+<span class="r4">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</span>
+</code></pre>
+</body>
+</html>
+"""
+    )
+
+
+def test_cli_output_svg(mock_script_writer: Callable[[str], Path]) -> None:
+    mock_script_writer(
+        '''
+        import rich_click as click
+
+        @click.command()
+        def cli():
+            """My help text"""
+        ''',
+    )
+
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "--output", "svg", "mymodule:cli", "--help"],
+    )
+    assert res.returncode == 0
+
+    assert res.stdout.decode() == snapshot(
+        """\
+<svg class="rich-terminal" viewBox="0 0 1238 245.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1043734155-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1043734155-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1043734155-r1 { fill: #c5c8c6 }
+.terminal-1043734155-r2 { fill: #d0b344 }
+.terminal-1043734155-r3 { fill: #c5c8c6;font-weight: bold }
+.terminal-1043734155-r4 { fill: #68a0b3;font-weight: bold }
+.terminal-1043734155-r5 { fill: #868887 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1043734155-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="194.2" />
+    </clipPath>
+    <clipPath id="terminal-1043734155-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1043734155-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1043734155-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1043734155-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1043734155-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1043734155-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1043734155-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="243.2" rx="8"/><text class="terminal-1043734155-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">mymodule&#160;--help</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        \n\
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1043734155-clip-terminal)">
+    \n\
+    <g class="terminal-1043734155-matrix">
+    <text class="terminal-1043734155-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-1043734155-line-0)">
+</text><text class="terminal-1043734155-r2" x="12.2" y="44.4" textLength="73.2" clip-path="url(#terminal-1043734155-line-1)">Usage:</text><text class="terminal-1043734155-r3" x="97.6" y="44.4" textLength="402.6" clip-path="url(#terminal-1043734155-line-1)">python&#160;-m&#160;src.rich_click.mymodule</text><text class="terminal-1043734155-r1" x="512.4" y="44.4" textLength="12.2" clip-path="url(#terminal-1043734155-line-1)">[</text><text class="terminal-1043734155-r4" x="524.6" y="44.4" textLength="85.4" clip-path="url(#terminal-1043734155-line-1)">OPTIONS</text><text class="terminal-1043734155-r1" x="610" y="44.4" textLength="12.2" clip-path="url(#terminal-1043734155-line-1)">]</text><text class="terminal-1043734155-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-1043734155-line-1)">
+</text><text class="terminal-1043734155-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-1043734155-line-2)">
+</text><text class="terminal-1043734155-r1" x="12.2" y="93.2" textLength="146.4" clip-path="url(#terminal-1043734155-line-3)">My&#160;help&#160;text</text><text class="terminal-1043734155-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-1043734155-line-3)">
+</text><text class="terminal-1043734155-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-1043734155-line-4)">
+</text><text class="terminal-1043734155-r5" x="0" y="142" textLength="24.4" clip-path="url(#terminal-1043734155-line-5)">╭─</text><text class="terminal-1043734155-r5" x="24.4" y="142" textLength="109.8" clip-path="url(#terminal-1043734155-line-5)">&#160;Options&#160;</text><text class="terminal-1043734155-r5" x="134.2" y="142" textLength="1061.4" clip-path="url(#terminal-1043734155-line-5)">───────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1043734155-r5" x="1195.6" y="142" textLength="24.4" clip-path="url(#terminal-1043734155-line-5)">─╮</text><text class="terminal-1043734155-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-1043734155-line-5)">
+</text><text class="terminal-1043734155-r5" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-1043734155-line-6)">│</text><text class="terminal-1043734155-r4" x="24.4" y="166.4" textLength="73.2" clip-path="url(#terminal-1043734155-line-6)">--help</text><text class="terminal-1043734155-r1" x="170.8" y="166.4" textLength="329.4" clip-path="url(#terminal-1043734155-line-6)">Show&#160;this&#160;message&#160;and&#160;exit.</text><text class="terminal-1043734155-r5" x="1207.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1043734155-line-6)">│</text><text class="terminal-1043734155-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-1043734155-line-6)">
+</text><text class="terminal-1043734155-r5" x="0" y="190.8" textLength="1220" clip-path="url(#terminal-1043734155-line-7)">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1043734155-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-1043734155-line-7)">
+</text>
+    </g>
+    </g>
+</svg>
+"""
+    )
+
+
+def test_cli_output_text(mock_script_writer: Callable[[str], Path]) -> None:
+    mock_script_writer(
+        '''
+        import rich_click as click
+
+        @click.command()
+        def cli():
+            """My help text"""
+        ''',
+    )
+
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "--output", "text", "mymodule:cli", "--help"],
+        # Even with FORCE_COLOR=True, no color should render with --output=text
+        env={"FORCE_COLOR": "True"},
+    )
+    assert res.returncode == 0
+
+    assert res.stdout.decode() == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: python -m src.rich_click.mymodule [OPTIONS]                                                 \n\
+                                                                                                    \n\
+ My help text                                                                                       \n\
+                                                                                                    \n\
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )


### PR DESCRIPTION
# High-Level Objectives

- Silently deprecate rich-click "groups"; rename to panel (maintain 100% backwards compatibility). This is a better namespace.
- Introduce new shimmed decorators for parameters that implement `RichParameter`s, with two key distinctions: (1) `help=` for arguments (2) 
- Introduce `click.panel()` decorator as new API for panels.
- Test coverage needs to go up as part of implementing all of this, e.g. help option, version option, etc. need full coverage.