### PR TITLE
[draft] rich-click CLI fixes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,5 +13,5 @@ jobs:
           python-version: 3
       - name: Install dependencies
         run: |
-          pip install --editable ".[dev]"
+          pip install ".[dev]"
       - uses: pre-commit-ci/lite-action@v1.1.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --editable ".[dev]"
+          uv pip install ".[dev]"
           uv pip install --upgrade "click==$CLICK_VERSION" --prerelease=allow
           uv pip install --upgrade "rich==$RICH_VERSION" --prerelease=allow
         env:

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --editable --prerelease allow ".[dev]"
+          uv pip install --prerelease allow ".[dev]"
 
       - name: Run tests
         run: pytest --cov --cov-report term

--- a/docs/code_snippets/panels/panels_panel_order_explicit_override.py
+++ b/docs/code_snippets/panels/panels_panel_order_explicit_override.py
@@ -14,5 +14,10 @@ def cli():
     """CLI help text"""
     pass
 
+@cli.command()
+def subcommand():
+    """Subcommand help text"""
+    pass
+
 if __name__ == "__main__":
     cli()

--- a/docs/documentation/panels.md
+++ b/docs/documentation/panels.md
@@ -248,19 +248,13 @@ This is probably a mistake, and there are two ways to fix it:
         -->
         ![`python panels_handling_help_fix_2.py --help`](../images/code_snippets/panels/panels_handling_help_fix_2.svg){.screenshot}
 
-### Ordering of panels
-
-!!! warning
-    **In 1.9.0dev0, options panels always come first and command panels always come after them.**
-    In a near future update, before 1.9.0 is fully released, you will be able to mix the order of panels.
-
-    The below text references the **intended** behavior for 1.9.0, but does not reflect the current behavior.
+### Sort order of panels
 
 Panels are printed in the order that they are defined, from top to bottom.
 
 If panels are inferred from `@click.option(panel=...)`, rather than defined by `@click.option_panel()`, then they are defined in the order that they appear in parameters from top to bottom.
 
-This means that the simplest way to control the order panels is to define them explicitly.
+**This means that the simplest way to control the order panels is to define them explicitly!**
 
 This also means that you can order options panels to come before command panels, and vice-versa, based on the decorator order.
 
@@ -279,7 +273,7 @@ By default, unless explicitly ordered otherwise, command panels always come afte
 
 
 There exists a config option `commands_before_options` (default `False`), which changes the default behavior so that commands come before options.
-**When explicitly defining panel order with decorators, this config option is ignored.**
+When explicitly defining panels of multiple types with decorators (i.e. both option panels and command panels), this config option is ignored.
 So for example, the below code will set options _above_ commands:
 
 ```python
@@ -292,6 +286,10 @@ So for example, the below code will set options _above_ commands:
     working_dir: docs/code_snippets/panels
     -->
     ![`python panels_panel_order_explicit_override.py --help`](../images/code_snippets/panels/panels_panel_order_explicit_override.svg){.screenshot}
+
+If you do not explicitly define panels, then the sort order behavior is more advanced.
+The sort order in all situations is deliberate and also thoroughly tested, but it's not worth going into detail about.
+In short, if you want to have full control over panel sorting, then you should define each panel!
 
 ### Ordering of rows within panels
 

--- a/src/rich_click/decorators.py
+++ b/src/rich_click/decorators.py
@@ -155,7 +155,7 @@ def command(
         if panels is not None:
             attr_panels = attrs.pop("panels", None)
             attr_panels = attr_panels if attr_panels is not None else []
-            attr_panels.extend(panels)
+            attr_panels.extend(reversed(panels))
             attrs["panels"] = attr_panels
             del f.__rich_panels__  # type: ignore[attr-defined]
 

--- a/src/rich_click/patch.py
+++ b/src/rich_click/patch.py
@@ -41,7 +41,7 @@ def rich_group(*args, **kwargs):  # type: ignore[no-untyped-def]
     return _rich_group(*args, **kwargs)
 
 
-def patch(rich_config: Optional[RichHelpConfiguration] = None, patch_rich_click: bool = True) -> None:
+def patch(rich_config: Optional[RichHelpConfiguration] = None, patch_rich_click: bool = False) -> None:
     """Patch Click internals to use rich-click types."""
     from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_9X
 

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -308,6 +308,9 @@ class RichMultiCommand(RichCommand, MultiCommand):  # type: ignore[valid-type,mi
     to print richly formatted output.
     """
 
+    def format_panels(self, ctx: RichContext, formatter: RichHelpFormatter) -> None:
+        pass
+
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         from rich_click.rich_help_rendering import get_rich_commands
 
@@ -479,7 +482,7 @@ def prevent_incompatible_overrides(
 
     cls: Type[RichCommand] = getattr(rich_click.patch, f"_Patched{class_name}")
 
-    for method_name in ["format_usage", "format_help_text", "format_options", "format_epilog"]:
+    for method_name in ["format_usage", "format_help_text", "format_options"]:
         if method_is_from_subclass_of(cmd.__class__, cls, method_name):
             getattr(RichCommand, method_name)(cmd, ctx, formatter)
         else:
@@ -488,3 +491,8 @@ def prevent_incompatible_overrides(
     if hasattr(cmd.__class__, "format_commands"):
         if method_is_from_subclass_of(cmd.__class__, cls, "format_commands"):
             getattr(RichMultiCommand, "format_commands")(cmd, ctx, formatter)
+
+    if method_is_from_subclass_of(cmd.__class__, cls, "format_epilog"):
+        getattr(RichCommand, "format_epilog")(cmd, ctx, formatter)
+    else:
+        getattr(cmd, "format_epilog")(ctx, formatter)

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -252,9 +252,15 @@ class RichCommand(click.Command):
     #  or (c) we use incorrect types here.
     #  We are looking for a solution that fixes all 3. For now, we opt for (c).
     def format_options(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        from rich_click.rich_help_rendering import get_rich_options
+        from rich.table import Table
 
-        get_rich_options(self, ctx, formatter)  # type: ignore[arg-type]
+        from rich_click.rich_panel import construct_panels
+
+        panels = construct_panels(self, ctx, formatter)  # type: ignore[arg-type]
+        for panel in panels:
+            p = panel.render(self, ctx, formatter)  # type: ignore[arg-type]
+            if not isinstance(p.renderable, Table) or len(p.renderable.rows) > 0:
+                formatter.write(p)  # type: ignore[arg-type]
 
     def format_epilog(self, ctx: RichContext, formatter: RichHelpFormatter) -> None:  # type: ignore[override]
         from rich_click.rich_help_rendering import get_rich_epilog
@@ -308,23 +314,9 @@ class RichMultiCommand(RichCommand, MultiCommand):  # type: ignore[valid-type,mi
     to print richly formatted output.
     """
 
-    def format_panels(self, ctx: RichContext, formatter: RichHelpFormatter) -> None:
-        pass
-
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        from rich_click.rich_help_rendering import get_rich_commands
-
-        get_rich_commands(self, ctx, formatter)  # type: ignore[arg-type]
-
-    def format_options(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        from rich_click.rich_help_rendering import get_rich_options
-
-        if isinstance(formatter, RichHelpFormatter) and formatter.config.commands_before_options:
-            self.format_commands(ctx, formatter)
-            get_rich_options(self, ctx, formatter)  # type: ignore[arg-type]
-        else:
-            get_rich_options(self, ctx, formatter)  # type: ignore[arg-type]
-            self.format_commands(ctx, formatter)
+        # Not used
+        pass
 
     def format_help(self, ctx: RichContext, formatter: RichHelpFormatter) -> None:  # type: ignore[override]
         if OVERRIDES_GUARD:
@@ -482,17 +474,8 @@ def prevent_incompatible_overrides(
 
     cls: Type[RichCommand] = getattr(rich_click.patch, f"_Patched{class_name}")
 
-    for method_name in ["format_usage", "format_help_text", "format_options"]:
+    for method_name in ["format_usage", "format_help_text", "format_options", "format_epilog"]:
         if method_is_from_subclass_of(cmd.__class__, cls, method_name):
             getattr(RichCommand, method_name)(cmd, ctx, formatter)
         else:
             getattr(cmd, method_name)(ctx, formatter)
-
-    if hasattr(cmd.__class__, "format_commands"):
-        if method_is_from_subclass_of(cmd.__class__, cls, "format_commands"):
-            getattr(RichMultiCommand, "format_commands")(cmd, ctx, formatter)
-
-    if method_is_from_subclass_of(cmd.__class__, cls, "format_epilog"):
-        getattr(RichCommand, "format_epilog")(cmd, ctx, formatter)
-    else:
-        getattr(cmd, "format_epilog")(ctx, formatter)

--- a/tests/fixtures/panels_sorting.py
+++ b/tests/fixtures/panels_sorting.py
@@ -9,14 +9,19 @@ import rich_click as click
 
 @click.group()
 @click.command_panel(
-    "Custom Command Panel 1",
+    "Custom Command Panel 2",
     # Order should be preserved
     commands=["cmd2", "cmd1"],
 )
 @click.command_panel(
-    "Custom Command Panel 2",
+    "Custom Command Panel 1",
     # Order should be preserved
     commands=["cmd3", "cmd4"],
+)
+@click.command_panel(
+    "Custom Command Panel 3",
+    # Order should be preserved
+    commands=["cmd5", "cmd6", "cmd7", "cmd8", "cmd9", "cmd10"],
 )
 def cli() -> None:
     """CLI help text"""
@@ -70,6 +75,84 @@ def cmd3(*args: Any, **kwargs: Any) -> None:
 @click.option_panel("Panel 3", options=["f", "--e"])
 def cmd4(*args: Any, **kwargs: Any) -> None:
     """Test order of options is preserved via option_panel()"""
+
+
+@cli.group()
+@click.option("--a")
+@click.command_panel("Commands")
+@click.option_panel("Options")
+def cmd5(*args: Any, **kwargs: Any) -> None:
+    """
+    Test that commands appear above options when explicitly set.
+    """
+
+
+@cli.group()
+@click.option("--a")
+@click.option_panel("Options")
+@click.command_panel("Commands")
+@click.rich_config({"commands_before_options": True})
+def cmd6(*args: Any, **kwargs: Any) -> None:
+    """
+    Test that options appear above commands when explicitly set,
+    ignoring the `commands_before_options` config option.
+    """
+
+
+@cli.group()
+@click.argument("a")
+@click.option("--b")
+@click.rich_config({"show_arguments": True})
+def cmd7(*args: Any, **kwargs: Any) -> None:
+    """
+    Test that default order is arguments -> options -> commands.
+    """
+
+
+@cli.group()
+@click.argument("a")
+@click.option("--b")
+@click.rich_config({"commands_before_options": True, "show_arguments": True})
+def cmd8(*args: Any, **kwargs: Any) -> None:
+    """
+    Test that default order is commands -> arguments -> options, when
+    commands show above options.
+    """
+
+
+@cli.group()
+@click.option("--samename", "samename", panel="Custom Opt Panel")
+@click.option("--dummy", panel="Custom Opt Panel")
+def cmd9(*args: Any, **kwargs: Any) -> None:
+    """
+    Test that command and option both having the same name
+    doesn't cause any issues. Also test that commands render by
+    assigned name in dict, not by the cmd.name.
+    """
+
+
+@cli.group()
+@click.option("--foo", panel="Generic Panel")
+@click.option("--bar", panel="Generic Panel")
+@click.command_panel("Generic Panel", commands=["dummy"])
+def cmd10(*args: Any, **kwargs: Any) -> None:
+    """
+    Test that command panel and option panel both having the same name
+    doesn't cause any issues.
+    """
+
+
+@click.command()
+def dummy() -> None:
+    pass
+
+
+cmd5.add_command(dummy)
+cmd6.add_command(dummy)
+cmd7.add_command(dummy)
+cmd8.add_command(dummy)
+cmd9.add_command(dummy, name="samename")
+cmd10.add_command(dummy)
 
 
 if __name__ == "__main__":

--- a/tests/help/test_class_overrides.py
+++ b/tests/help/test_class_overrides.py
@@ -78,13 +78,13 @@ def test_class_overrides_click_parameters(cli_runner: CliRunner, cli: rich_click
                                                                                                     \n\
  Test that options+arguments are assigned to the panel even if they're not RichParameters.          \n\
                                                                                                     \n\
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Rich Click Panel ───────────────────────────────────────────────────────────────────────────────╮
 │ *  CLICK-ARG         TEXT  [required]                                                            │
 │ *  --click-option    TEXT  This is help text for a click.Option(). [env var: CLICK_OPTION]       │
 │                            [default: foo]                          [required]                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )

--- a/tests/help/test_panels_defaults.py
+++ b/tests/help/test_panels_defaults.py
@@ -25,11 +25,6 @@ def test_panels_defaults_command_panel(cli_runner: CliRunner, cli: rich_click.Ri
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help      Show this message and exit.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-   Custom Default Command Panel                                                                     \n\
-  cmd1                             cmd1 help                                                        \n\
-  cmd2                             cmd2 help                                                        \n\
-  cmd3                             cmd3 help                                                        \n\
-                                                                                                    \n\
    Command Panel A                                                                                  \n\
   cmd4  Test args assigned to arguments panel when help is defined, and test that arg3 is assigned  \n\
         to default even without help so long as panel shows.                                        \n\
@@ -43,6 +38,11 @@ def test_panels_defaults_command_panel(cli_runner: CliRunner, cli: rich_click.Ri
 ║ cmd8  Test options and arguments are assigned to a renamed default options panel with            ║
 ║       group_arguments_options=True                                                               ║
 ╚══════════════════════════════════════════════════════════════════════════════════════════════════╝
+   Custom Default Command Panel                                                                     \n\
+  cmd1                             cmd1 help                                                        \n\
+  cmd2                             cmd2 help                                                        \n\
+  cmd3                             cmd3 help                                                        \n\
+                                                                                                    \n\
 """
     )
     assert result.stderr == snapshot("")

--- a/tests/help/test_panels_sorting.py
+++ b/tests/help/test_panels_sorting.py
@@ -25,13 +25,25 @@ def test_command_panel_order(cli_runner: CliRunner, cli: rich_click.RichCommand)
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help      Show this message and exit.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Custom Command Panel 1 ─────────────────────────────────────────────────────────────────────────╮
+╭─ Custom Command Panel 2 ─────────────────────────────────────────────────────────────────────────╮
 │ cmd2       Test order of options is preserved via panel...                                       │
 │ cmd1       Test order of panels is preserved via panel=...                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Custom Command Panel 2 ─────────────────────────────────────────────────────────────────────────╮
+╭─ Custom Command Panel 1 ─────────────────────────────────────────────────────────────────────────╮
 │ cmd3      Test order of panels is preserved via option_panel()                                   │
 │ cmd4      Test order of options is preserved via option_panel()                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Custom Command Panel 3 ─────────────────────────────────────────────────────────────────────────╮
+│ cmd5   Test that commands appear above options when explicitly set.                              │
+│ cmd6   Test that options appear above commands when explicitly set, ignoring the                 │
+│        `commands_before_options` config option.                                                  │
+│ cmd7   Test that default order is arguments -> options -> commands.                              │
+│ cmd8   Test that default order is commands -> arguments -> options, when commands show above     │
+│        options.                                                                                  │
+│ cmd9   Test that command and option both having the same name doesn't cause any issues. Also     │
+│        test that commands render by assigned name in dict, not by the cmd.name.                  │
+│ cmd10  Test that command panel and option panel both having the same name doesn't cause any      │
+│        issues.                                                                                   │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )
@@ -108,9 +120,6 @@ def test_panel_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.Ric
                                                                                                     \n\
  Test order of panels is preserved via option_panel()                                               \n\
                                                                                                     \n\
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Panel 2 ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --a  -a  TEXT  Help text for A                                                                   │
 │ --b  -b  TEXT  Help text for B                                                                   │
@@ -122,6 +131,9 @@ def test_panel_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.Ric
 ╭─ Panel 3 ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --e  -e  TEXT  Help text for E                                                                   │
 │ --f  -f  TEXT  Help text for F                                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )
@@ -138,9 +150,6 @@ def test_option_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.Ri
                                                                                                     \n\
  Test order of options is preserved via option_panel()                                              \n\
                                                                                                     \n\
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Panel 1 ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --a  -a  TEXT  Help text for A                                                                   │
 │ --b  -b  TEXT  Help text for B                                                                   │
@@ -152,6 +161,155 @@ def test_option_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.Ri
 ╭─ Panel 3 ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --f  -e  TEXT  Help text for E                                                                   │
 │ --e  -f  TEXT  Help text for F                                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+    )
+    assert result.stderr == snapshot("")
+
+
+def test_panel_order_commands_above_options(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
+    result = cli_runner.invoke(cli, "cmd5 --help")
+    assert result.exit_code == 0
+    assert result.stdout == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: cli cmd5 [OPTIONS] COMMAND [ARGS]...                                                        \n\
+                                                                                                    \n\
+ Test that commands appear above options when explicitly set.                                       \n\
+                                                                                                    \n\
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ dummy                                                                                            │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --a       TEXT                                                                                   │
+│ --help          Show this message and exit.                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+    )
+    assert result.stderr == snapshot("")
+
+
+def test_panel_order_options_above_commands(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
+    result = cli_runner.invoke(cli, "cmd6 --help")
+    assert result.exit_code == 0
+    assert result.stdout == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: cli cmd6 [OPTIONS] COMMAND [ARGS]...                                                        \n\
+                                                                                                    \n\
+ Test that options appear above commands when explicitly set, ignoring the                          \n\
+ `commands_before_options` config option.                                                           \n\
+                                                                                                    \n\
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --a       TEXT                                                                                   │
+│ --help          Show this message and exit.                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ dummy                                                                                            │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+    )
+    assert result.stderr == snapshot("")
+
+
+def test_panel_order_options_above_commands_with_arguments(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
+    result = cli_runner.invoke(cli, "cmd7 --help")
+    assert result.exit_code == 0
+    assert result.stdout == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: cli cmd7 [OPTIONS] A COMMAND [ARGS]...                                                      \n\
+                                                                                                    \n\
+ Test that default order is arguments -> options -> commands.                                       \n\
+                                                                                                    \n\
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
+│ *  A    TEXT  [required]                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --b       TEXT                                                                                   │
+│ --help          Show this message and exit.                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ dummy                                                                                            │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+    )
+    assert result.stderr == snapshot("")
+
+
+def test_panel_order_arguments_options_commands(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
+    result = cli_runner.invoke(cli, "cmd8 --help")
+    assert result.exit_code == 0
+    assert result.stdout == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: cli cmd8 [OPTIONS] A COMMAND [ARGS]...                                                      \n\
+                                                                                                    \n\
+ Test that default order is commands -> arguments -> options, when commands show above options.     \n\
+                                                                                                    \n\
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ dummy                                                                                            │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
+│ *  A    TEXT  [required]                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --b       TEXT                                                                                   │
+│ --help          Show this message and exit.                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+    )
+    assert result.stderr == snapshot("")
+
+
+def test_panel_option_and_command_same_name(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
+    result = cli_runner.invoke(cli, "cmd9 --help")
+    assert result.exit_code == 0
+    assert result.stdout == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: cli cmd9 [OPTIONS] COMMAND [ARGS]...                                                        \n\
+                                                                                                    \n\
+ Test that command and option both having the same name doesn't cause any issues. Also test that    \n\
+ commands render by assigned name in dict, not by the cmd.name.                                     \n\
+                                                                                                    \n\
+╭─ Custom Opt Panel ───────────────────────────────────────────────────────────────────────────────╮
+│ --samename    TEXT                                                                               │
+│ --dummy       TEXT                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ samename                                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+"""
+    )
+    assert result.stderr == snapshot("")
+
+
+def test_panel_different_type_panels_same_name(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
+    result = cli_runner.invoke(cli, "cmd10 --help")
+    assert result.exit_code == 0
+    assert result.stdout == snapshot(
+        """\
+                                                                                                    \n\
+ Usage: cli cmd10 [OPTIONS] COMMAND [ARGS]...                                                       \n\
+                                                                                                    \n\
+ Test that command panel and option panel both having the same name doesn't cause any issues.       \n\
+                                                                                                    \n\
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Generic Panel ──────────────────────────────────────────────────────────────────────────────────╮
+│ dummy                                                                                            │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Generic Panel ──────────────────────────────────────────────────────────────────────────────────╮
+│ --foo    TEXT                                                                                    │
+│ --bar    TEXT                                                                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )

--- a/tests/help/test_panels_styles.py
+++ b/tests/help/test_panels_styles.py
@@ -8,11 +8,11 @@ from tests.conftest import load_command_from_module
 
 @pytest.fixture
 def cli() -> rich_click.RichCommand:
-    cmd = load_command_from_module("tests.fixtures.panels_sorting")
+    cmd = load_command_from_module("tests.fixtures.panels_styles")
     return cmd
 
 
-def test_command_panel_order(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
+def test_styles_command_panel(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
     assert result.stdout == snapshot(
@@ -20,138 +20,40 @@ def test_command_panel_order(cli_runner: CliRunner, cli: rich_click.RichCommand)
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
- CLI help text                                                                                      \n\
+ Test basic styles for command panel.                                                               \n\
                                                                                                     \n\
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help      Show this message and exit.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Custom Command Panel 1 ─────────────────────────────────────────────────────────────────────────╮
-│ cmd2       Test order of options is preserved via panel...                                       │
-│ cmd1       Test order of panels is preserved via panel=...                                       │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Custom Command Panel 2 ─────────────────────────────────────────────────────────────────────────╮
-│ cmd3      Test order of panels is preserved via option_panel()                                   │
-│ cmd4      Test order of options is preserved via option_panel()                                  │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+   Custom Panel                                                                                     \n\
+  This is help text for the command panel.                                                          \n\
+  subcommand              Test basic styles for option panel.                                       \n\
+                                        Additional Commands                                         \n\
+                                                                                                    \n\
 """
     )
     assert result.stderr == snapshot("")
 
 
-def test_panel_order_in_panel_decorator(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
-    result = cli_runner.invoke(cli, "cmd1 --help")
+def test_styles_options_panel(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
+    result = cli_runner.invoke(cli, "subcommand --help")
     assert result.exit_code == 0
     assert result.stdout == snapshot(
         """\
                                                                                                     \n\
- Usage: cli cmd1 [OPTIONS]                                                                          \n\
+ Usage: cli subcommand [OPTIONS]                                                                    \n\
                                                                                                     \n\
- Test order of panels is preserved via panel=...                                                    \n\
+ Test basic styles for option panel.                                                                \n\
                                                                                                     \n\
-╭─ Custom 2 ───────────────────────────────────────────────────────────────────────────────────────╮
-│ --a  -a  TEXT  Help text for A                                                                   │
-│ --c  -c  TEXT  Help text for C                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Custom 1 ───────────────────────────────────────────────────────────────────────────────────────╮
-│ --b  -b  TEXT  Help text for B                                                                   │
-│ --e  -e  TEXT  Help text for E                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Custom 3 ───────────────────────────────────────────────────────────────────────────────────────╮
-│ --f  -f  TEXT  Help text for F                                                                   │
-│ --d  -d  TEXT  Help text for E                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
-    assert result.stderr == snapshot("")
-
-
-def test_option_order_with_panel_decorator(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
-    result = cli_runner.invoke(cli, "cmd2 --help")
-    assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
-                                                                                                    \n\
- Usage: cli cmd2 [OPTIONS]                                                                          \n\
-                                                                                                    \n\
- Test order of options is preserved via panel...                                                    \n\
-                                                                                                    \n\
-╭─ Custom 1 ───────────────────────────────────────────────────────────────────────────────────────╮
-│ --a  -a  TEXT  Help text for A                                                                   │
-│ --b  -b  TEXT  Help text for B                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Custom 2 ───────────────────────────────────────────────────────────────────────────────────────╮
-│ --d  -d  TEXT  Help text for D                                                                   │
-│ --c  -c  TEXT  Help text for C                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Custom 3 ───────────────────────────────────────────────────────────────────────────────────────╮
-│ --f  -f  TEXT  Help text for F                                                                   │
-│ --e  -e  TEXT  Help text for E                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
-    assert result.stderr == snapshot("")
-
-
-def test_panel_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
-    result = cli_runner.invoke(cli, "cmd3 --help")
-    assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
-                                                                                                    \n\
- Usage: cli cmd3 [OPTIONS]                                                                          \n\
-                                                                                                    \n\
- Test order of panels is preserved via option_panel()                                               \n\
+   Custom Panel                                                                                     \n\
+  This is help text for the option panel.                                                           \n\
+  --a  -a  TEXT  Help text for A                                                                    \n\
+  --b  -b  TEXT  Help text for B                                                                    \n\
+  --c  -c  TEXT  Help text for C                                                                    \n\
+                                         Additional Options                                         \n\
                                                                                                     \n\
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help      Show this message and exit.                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Panel 2 ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --a  -a  TEXT  Help text for A                                                                   │
-│ --b  -b  TEXT  Help text for B                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Panel 1 ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --c  -c  TEXT  Help text for C                                                                   │
-│ --d  -d  TEXT  Help text for D                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Panel 3 ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --e  -e  TEXT  Help text for E                                                                   │
-│ --f  -f  TEXT  Help text for F                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
-    assert result.stderr == snapshot("")
-
-
-def test_option_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
-    result = cli_runner.invoke(cli, "cmd4 --help")
-    assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
-                                                                                                    \n\
- Usage: cli cmd4 [OPTIONS]                                                                          \n\
-                                                                                                    \n\
- Test order of options is preserved via option_panel()                                              \n\
-                                                                                                    \n\
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                          │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Panel 1 ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --a  -a  TEXT  Help text for A                                                                   │
-│ --b  -b  TEXT  Help text for B                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Panel 2 ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --d  -d  TEXT  Help text for C                                                                   │
-│ --c  -c  TEXT  Help text for D                                                                   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Panel 3 ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --f  -e  TEXT  Help text for E                                                                   │
-│ --e  -f  TEXT  Help text for F                                                                   │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )


### PR DESCRIPTION
Something fishy about how the rich-click CLI works in all honesty.

Since `format_options()` calls `format_commands()`, it doesn't seem that `format_commands()` should need to be directly called. I imagine what is happening is that `RichCommand.format_options` is being called rather than `RichGroup.format_options`. This needs to be fixed.

(Also, there was a minor bug in how the epilog was placed before `format_commands`. That is fixed here as well.)