### PR TITLE
should not be writing to devnull, should instead write to unused buffer

### DIFF
--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+import io
 import sys
 from contextlib import contextmanager
 from functools import cached_property
@@ -78,7 +78,7 @@ def create_console(
     )
     # Defaults for console.color_system change when file is in __init__.
     # Workaround: set file after __init__.
-    console.file = file or open(os.devnull, "w")
+    console.file = file or io.StringIO()
     max_width = max_width if max_width is not None else config.max_width
     if isinstance(max_width, int):
         console.width = min(max_width, console.size.width)


### PR DESCRIPTION
Discussion in integration tests issue made me realize `/dev/null` isn't the proper place to be writing the console to. It would be better to write to a `StringIO()`. This accomplishes the same thing but doesn't cause any noise hitting to `/dev/null`.