### PR TITLE
Add RichCliRunner for testing Rich prompt/output capture

### DIFF
--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -91,6 +91,7 @@ from rich_click.rich_panel import RichPanel as RichPanel
 from rich_click.rich_parameter import RichArgument as RichArgument
 from rich_click.rich_parameter import RichOption as RichOption
 from rich_click.rich_parameter import RichParameter as RichParameter
+from rich_click.testing import RichCliRunner as RichCliRunner
 
 from . import rich_click as rich_click
 

--- a/src/rich_click/patch.py
+++ b/src/rich_click/patch.py
@@ -26,7 +26,6 @@ __TyperOption: Type["typer.core.TyperOption"]
 
 
 class _PatchedTyperContext(RichContext):
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         RichContext.__init__(self, *args, **kwargs)
 

--- a/src/rich_click/rich_command.pyi
+++ b/src/rich_click/rich_command.pyi
@@ -41,7 +41,6 @@ G = TypeVar("G", bound=click.Group)
 OVERRIDES_GUARD: bool = False
 
 class RichCommand(click.Command):
-
     context_class: Type[RichContext] = RichContext
     _formatter: Optional[RichHelpFormatter] = None
     panels: List[RichPanel[Any, Any]]

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -163,7 +163,7 @@ class RichHelpFormatter(click.HelpFormatter):
             import warnings
 
             warnings.warn(
-                "The file kwarg to `RichHelpFormatter()` is deprecated" " and will be removed in a future release.",
+                "The file kwarg to `RichHelpFormatter()` is deprecated and will be removed in a future release.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -327,7 +327,7 @@ class RichHelpFormatter(click.HelpFormatter):
                 res = self.console.export_svg(**kw)
             else:
                 raise ValueError(
-                    "Invalid value for `export_console_as`." " Must be one of 'text', 'html', 'svg', or None."
+                    "Invalid value for `export_console_as`. Must be one of 'text', 'html', 'svg', or None."
                 )
             return res
         else:

--- a/src/rich_click/rich_help_rendering.py
+++ b/src/rich_click/rich_help_rendering.py
@@ -1088,7 +1088,6 @@ def rich_format_error(
     # attribute. Checking for the 'message' attribute works to make the
     # rich-click CLI compatible.
     if hasattr(self, "message"):
-
         from rich_click.rich_box import get_box
 
         formatter.write(

--- a/src/rich_click/rich_panel.py
+++ b/src/rich_click/rich_panel.py
@@ -280,7 +280,6 @@ class RichOptionPanel(RichPanel[Parameter, OptionColumnType]):
                 inline_help_in_title = self.inline_help_in_title
 
             if inline_help_in_title:
-
                 p_styles["title"] = Text("", overflow="ellipsis").join(
                     [
                         Text(title, style=title_style),
@@ -334,7 +333,6 @@ class RichCommandPanel(RichPanel[Command, CommandColumnType]):
         callback_names = {c.callback.__name__: c for c in command.commands.values() if c.callback is not None}
 
         for cmd_name in self.commands:
-
             if cmd_name in commands_list:
                 yield command.get_command(ctx, cmd_name)  # type: ignore[misc]
             elif cmd_name in callback_names:
@@ -382,7 +380,6 @@ class RichCommandPanel(RichPanel[Command, CommandColumnType]):
         rows = []
 
         for cmd in self.get_objects(command, ctx):
-
             from rich_click.rich_command import RichCommand
             from rich_click.rich_help_rendering import get_command_rich_table_row
 
@@ -448,7 +445,6 @@ class RichCommandPanel(RichPanel[Command, CommandColumnType]):
                 inline_help_in_title = self.inline_help_in_title
 
             if inline_help_in_title:
-
                 p_styles["title"] = Text("", overflow="ellipsis").join(
                     [
                         Text(title, style=title_style),
@@ -508,7 +504,6 @@ def _resolve_panels_from_config(
             opts: List[str] = grp.get(panel_cls._object_attr, [])  # type: ignore[assignment]
             traversed = []
             for opt in grp.get(panel_cls._object_attr, []):  # type: ignore[attr-defined]
-
                 if grp.get("deduplicate", True) and opt in [
                     _opt
                     for _grp in final_groups_list

--- a/src/rich_click/testing.py
+++ b/src/rich_click/testing.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator, Mapping, Optional, TextIO, Tuple, Union
+
+from click.testing import CliRunner
+
+
+class RichCliRunner(CliRunner):
+    """CliRunner that rebinds Rich's global console during isolation.
+
+    Rich caches a process-global console instance. If that console is created
+    before Click's ``CliRunner`` swaps ``sys.stdin`` / ``sys.stdout`` / ``sys.stderr``,
+    Rich prompts and prints will keep writing to the original streams.
+
+    This subclass temporarily points Rich's global console at Click's isolated
+    streams so tests can assert on Rich output (including prompt rendering).
+    """
+
+    @contextmanager
+    def isolation(  # type: ignore[override]
+        self,
+        input: Union[str, bytes, TextIO, None] = None,
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        color: bool = False,
+    ) -> Iterator[Tuple[object, object, object]]:
+        import sys
+
+        import rich
+        from rich.console import Console
+
+        old_console = rich._console  # type: ignore[attr-defined]
+
+        with super().isolation(input=input, env=env, color=color) as streams:
+            rich._console = Console(file=sys.stdout, force_terminal=color)  # type: ignore[attr-defined]
+            try:
+                yield streams
+            finally:
+                rich._console = old_console  # type: ignore[attr-defined]

--- a/src/rich_click/testing.py
+++ b/src/rich_click/testing.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Iterator, Mapping, Optional, TextIO, Tuple, Union
+from typing import IO, Any, Iterator, Mapping
 
 from click.testing import CliRunner
 
 
 class RichCliRunner(CliRunner):
-    """CliRunner that rebinds Rich's global console during isolation.
+    """
+    CliRunner that rebinds Rich's global console during isolation.
 
     Rich caches a process-global console instance. If that console is created
     before Click's ``CliRunner`` swaps ``sys.stdin`` / ``sys.stdout`` / ``sys.stderr``,
@@ -18,22 +19,22 @@ class RichCliRunner(CliRunner):
     """
 
     @contextmanager
-    def isolation(  # type: ignore[override]
+    def isolation(
         self,
-        input: Union[str, bytes, TextIO, None] = None,
-        env: Optional[Mapping[str, Optional[str]]] = None,
+        input: str | bytes | IO[Any] | None = None,
+        env: Mapping[str, str | None] | None = None,
         color: bool = False,
-    ) -> Iterator[Tuple[object, object, object]]:
+    ) -> Iterator[Any]:
         import sys
 
         import rich
         from rich.console import Console
 
-        old_console = rich._console  # type: ignore[attr-defined]
+        old_console = getattr(rich, "_console", None)
 
         with super().isolation(input=input, env=env, color=color) as streams:
-            rich._console = Console(file=sys.stdout, force_terminal=color)  # type: ignore[attr-defined]
+            setattr(rich, "_console", Console(file=sys.stdout, force_terminal=color))
             try:
                 yield streams
             finally:
-                rich._console = old_console  # type: ignore[attr-defined]
+                setattr(rich, "_console", old_console)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,38 @@
+import io
+
+import click
+import rich
+from click.testing import CliRunner
+from rich.console import Console
+from rich.prompt import Prompt
+
+from rich_click.testing import RichCliRunner
+
+
+@click.command()
+def cli() -> None:
+    name = Prompt.ask("Name")
+    click.echo(f"Hello {name}")
+
+
+def test_rich_cli_runner_captures_prompt_when_global_console_is_customized() -> None:
+    # Simulate application startup code that configured a global Rich console.
+    rich._console = Console(file=io.StringIO())  # type: ignore[attr-defined]
+
+    runner = RichCliRunner()
+    result = runner.invoke(cli, input="Jane\n")
+
+    assert result.exit_code == 0
+    assert "Name" in result.output
+    assert "Hello Jane" in result.output
+
+
+def test_click_cli_runner_does_not_capture_prompt_when_global_console_is_customized() -> None:
+    rich._console = Console(file=io.StringIO())  # type: ignore[attr-defined]
+
+    runner = CliRunner()
+    result = runner.invoke(cli, input="Jane\n")
+
+    assert result.exit_code == 0
+    assert "Hello Jane" in result.output
+    assert "Name" not in result.output

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -17,7 +17,7 @@ def cli() -> None:
 
 def test_rich_cli_runner_captures_prompt_when_global_console_is_customized() -> None:
     # Simulate application startup code that configured a global Rich console.
-    rich._console = Console(file=io.StringIO())  # type: ignore[attr-defined]
+    rich._console = Console(file=io.StringIO())
 
     runner = RichCliRunner()
     result = runner.invoke(cli, input="Jane\n")
@@ -28,7 +28,7 @@ def test_rich_cli_runner_captures_prompt_when_global_console_is_customized() -> 
 
 
 def test_click_cli_runner_does_not_capture_prompt_when_global_console_is_customized() -> None:
-    rich._console = Console(file=io.StringIO())  # type: ignore[attr-defined]
+    rich._console = Console(file=io.StringIO())
 
     runner = CliRunner()
     result = runner.invoke(cli, input="Jane\n")


### PR DESCRIPTION
## Summary
- add `rich_click.testing.RichCliRunner`, a `click.testing.CliRunner` subclass
- rebind Rich's global cached console during `CliRunner.isolation()` so output goes to Click's isolated stdout/stderr streams
- restore the previous global Rich console after invocation to avoid leaking test state
- export `RichCliRunner` from `rich_click`
- add regression tests covering prompt capture behavior with a preconfigured global Rich console

## Why
When Rich's global console has already been initialized before `CliRunner.invoke()`, prompt / console output may go to the pre-existing console stream instead of Click's test-captured streams. This makes asserting Rich prompt output difficult in tests.

This change provides a dedicated runner for Rich-based CLIs that keeps Rich aligned with Click's test isolation.

Closes #232.
