### PR TITLE
Harden GitHub Actions workflows (zizmor)

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,10 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        # persisted credentials are required for the rich-codex step to push commits
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 # zizmor: ignore[artipacked]
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: 3
           activate-environment: true
@@ -31,7 +32,7 @@ jobs:
 
       - name: Generate terminal images with rich-codex
         if: github.repository_owner == 'ewels' || github.event_name == 'workflow_dispatch'
-        uses: ewels/rich-codex@v1
+        uses: ewels/rich-codex@80de9de011c994f32274bb4cffee140567621d8e # v1.2.11
         with:
           skip_python_setup: "true"
           commit_changes: "true"

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -3,16 +3,25 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   build-n-publish:
     if: github.repository == 'ewels/rich-click'
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rich-click
+    permissions:
+      id-token: write  # Required for PyPI Trusted Publishing (OIDC)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         name: Check out source-code repository
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -23,6 +32,4 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,13 +3,19 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: 3
           activate-environment: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,9 +4,13 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -38,10 +42,12 @@ jobs:
             typer: 0.25.*
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python }}
           activate-environment: true

--- a/.github/workflows/rich-codex.yml
+++ b/.github/workflows/rich-codex.yml
@@ -2,15 +2,20 @@ name: Rich-codex
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   rich_codex:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # rich-codex commits & pushes generated screenshots
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        # persisted credentials are required for rich-codex to push commits
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 # zizmor: ignore[artipacked]
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: 3
           activate-environment: true
@@ -19,7 +24,7 @@ jobs:
         run: uv pip install ".[docs]"
 
       - name: Generate terminal images with rich-codex
-        uses: ewels/rich-codex@v1
+        uses: ewels/rich-codex@80de9de011c994f32274bb4cffee140567621d8e # v1.2.11
         with:
           use_uv: "true"
           skip_python_setup: "true"

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -4,19 +4,25 @@ on:
   schedule:
     - cron: '0 0 * * 6'  # Every Saturday at 00:00
 
+permissions: {}
+
 jobs:
   test:
     if: github.event_name != 'schedule' || github.repository == 'ewels/rich-click'
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python }}
           activate-environment: true

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,8 +1,11 @@
 name: Test Examples
 on: [push, pull_request]
+permissions: {}
 jobs:
   examples:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         python: ["3.8", "3.13"]
@@ -14,10 +17,12 @@ jobs:
             click: 8.3.*
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python }}
           activate-environment: true


### PR DESCRIPTION
Cleans up all [zizmor](https://docs.zizmor.sh) findings across the workflows.

- **PyPI publishing → Trusted Publishing (OIDC).** `deploy-pypi.yml` now authenticates via OIDC through a `pypi` GitHub Environment instead of the `PYPI_API_TOKEN` secret. `pypa/gh-action-pypi-publish` is pinned to a SHA (`v1.14.0`).
- **Minimal `permissions:` blocks** on every job — `contents: read` for test/lint jobs, `contents: write` for rich-codex (it commits screenshots), `id-token: write` for the publish job. Top-level `permissions: {}` everywhere.
- **`persist-credentials: false`** on checkouts that don't need to push.
- Persisted credentials kept only where the rich-codex step pushes commits (`build-docs.yml`, `rich-codex.yml`), with a documented `zizmor: ignore[artipacked]`.

`zizmor .github/workflows/` now reports **no findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)