### PR TITLE
Fix RichContext errors_in_output_format inheritance guard

### DIFF
--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -61,7 +61,7 @@ class RichContext(click.Context):
         else:
             self.export_console_as = export_console_as or self.export_console_as
 
-        if errors_in_output_format is None and hasattr(parent, "export_console_as"):
+        if errors_in_output_format is None and hasattr(parent, "errors_in_output_format"):
             self.errors_in_output_format = parent.errors_in_output_format  # type: ignore[union-attr]
         else:
             self.errors_in_output_format = errors_in_output_format or self.errors_in_output_format

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -6,6 +6,7 @@ from inline_snapshot import snapshot
 import rich_click
 import rich_click.rich_click as rc
 from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_821
+from rich_click.rich_context import RichContext
 from rich_click.utils import truthy
 
 
@@ -25,6 +26,19 @@ def test_abort(cli_runner: CliRunner) -> None:
 \x1b[31mAborted.\x1b[0m
 """
     )
+
+
+def test_child_context_inherits_errors_in_output_format() -> None:
+    # A child context inherits errors_in_output_format from its parent. Locks in the contract:
+    # the inheritance guard used to check the wrong attribute name (harmless while both are
+    # class-level defaults, but only correct by accident).
+    @rich_click.command()
+    def cli() -> None:
+        """CLI."""
+
+    parent = RichContext(cli, errors_in_output_format=True)
+    child = RichContext(cli, parent=parent)
+    assert child.errors_in_output_format is True
 
 
 def test_truthy() -> None:


### PR DESCRIPTION
## What

`RichContext.__init__` inherits a handful of attributes from the parent context. The guard for `errors_in_output_format` checked the wrong attribute name:

```python
if errors_in_output_format is None and hasattr(parent, "export_console_as"):  # wrong attr
    self.errors_in_output_format = parent.errors_in_output_format
```

It should check `hasattr(parent, "errors_in_output_format")`, matching the sibling blocks for `help_to_stderr` and `export_console_as`.

## Impact

Behaviourally neutral today: both `export_console_as` and `errors_in_output_format` are class-level defaults, so the `hasattr` check on a `RichContext` parent is always `True` either way and inheritance still happens. The guard was only correct by accident — this corrects the intent and makes it robust if those attributes ever become instance-only.

## Test

Adds `test_child_context_inherits_errors_in_output_format`, locking in the inheritance contract.

Spotted while reviewing #331.