### PR TITLE
rich-click CLI: --output json for machine-readable help

### DIFF
--- a/docs/documentation/machine_readable_help.md
+++ b/docs/documentation/machine_readable_help.md
@@ -18,6 +18,8 @@ This adds a global `--help-json` flag to every command and group:
 
 See the [Configuration](configuration.md) page for how to set config options globally or per-command with the `rich_config` decorator.
 
+You can also get JSON help for _any_ Click CLI — even one that hasn't opted in — with the [rich-click CLI](rich_click_cli.md#render-help-as-json): `rich-click --output=json [command] --help`.
+
 ## Example output
 
 Running the top-level command with `--help-json` prints the current command's help, usage and full parameter detail as JSON, together with a recursive index of subcommand names:

--- a/docs/documentation/rich_click_cli.md
+++ b/docs/documentation/rich_click_cli.md
@@ -44,6 +44,27 @@ You can also use `rich-click --output=html [command]` to render rich HTML for he
 
 This works for RichCommands as well as normal click Commands.
 
+## Render help as JSON
+
+Use `rich-click --output=json [command] --help` to emit a command's [machine-readable `--help-json` schema](machine_readable_help.md) instead of the rendered help text. This works for any Click CLI, without the target needing to opt into `help_json` itself:
+
+```console
+$ rich-click --output=json flask --help
+{
+  "name": "flask",
+  "path": "flask",
+  ...
+}
+```
+
+`--output` also applies to the `--help-json` flag itself, letting you export the schema in another format. The two parts are independent: `--help-json` decides the content (the JSON), `--output` decides the format. So to get an SVG image _of the JSON_ (rather than of the rendered help), combine them:
+
+```console
+$ rich-click -c '{"help_json": true}' --output=svg flask --help-json
+```
+
+Here `-c '{"help_json": true}'` enables the `--help-json` flag on the target, and `--output=svg` exports its JSON as an SVG.
+
 SVG example:
 
 <!-- RICH-CODEX

--- a/docs/images/code_snippets/help_json/help_json.svg
+++ b/docs/images/code_snippets/help_json/help_json.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 416.0" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 440.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,100 +19,104 @@
         font-weight: 700;
     }
 
-    .terminal-4292986184-matrix {
+    .terminal-3840462070-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-4292986184-title {
+    .terminal-3840462070-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-4292986184-r1 { fill: #c5c8c6 }
-.terminal-4292986184-r2 { fill: #d0b344 }
-.terminal-4292986184-r3 { fill: #c5c8c6;font-weight: bold }
-.terminal-4292986184-r4 { fill: #68a0b3;font-weight: bold }
-.terminal-4292986184-r5 { fill: #868887 }
-.terminal-4292986184-r6 { fill: #98a84b;font-weight: bold }
+    .terminal-3840462070-r1 { fill: #c5c8c6 }
+.terminal-3840462070-r2 { fill: #d0b344 }
+.terminal-3840462070-r3 { fill: #c5c8c6;font-weight: bold }
+.terminal-3840462070-r4 { fill: #68a0b3;font-weight: bold }
+.terminal-3840462070-r5 { fill: #868887 }
+.terminal-3840462070-r6 { fill: #98a84b;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-4292986184-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="365.0" />
+    <clipPath id="terminal-3840462070-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="389.4" />
     </clipPath>
-    <clipPath id="terminal-4292986184-line-0">
+    <clipPath id="terminal-3840462070-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-1">
+<clipPath id="terminal-3840462070-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-2">
+<clipPath id="terminal-3840462070-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-3">
+<clipPath id="terminal-3840462070-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-4">
+<clipPath id="terminal-3840462070-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-5">
+<clipPath id="terminal-3840462070-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-6">
+<clipPath id="terminal-3840462070-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-7">
+<clipPath id="terminal-3840462070-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-8">
+<clipPath id="terminal-3840462070-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-9">
+<clipPath id="terminal-3840462070-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-10">
+<clipPath id="terminal-3840462070-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-11">
+<clipPath id="terminal-3840462070-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-12">
+<clipPath id="terminal-3840462070-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-4292986184-line-13">
+<clipPath id="terminal-3840462070-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3840462070-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="414" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="438.4" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-4292986184-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3840462070-clip-terminal)">
     
-    <g class="terminal-4292986184-matrix">
-    <text class="terminal-4292986184-r1" x="0" y="20" textLength="341.6" clip-path="url(#terminal-4292986184-line-0)">$&#160;python&#160;help_json.py&#160;--help</text><text class="terminal-4292986184-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-4292986184-line-0)">
-</text><text class="terminal-4292986184-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-4292986184-line-1)">
-</text><text class="terminal-4292986184-r2" x="12.2" y="68.8" textLength="73.2" clip-path="url(#terminal-4292986184-line-2)">Usage:</text><text class="terminal-4292986184-r3" x="97.6" y="68.8" textLength="146.4" clip-path="url(#terminal-4292986184-line-2)">help_json.py</text><text class="terminal-4292986184-r1" x="244" y="68.8" textLength="24.4" clip-path="url(#terminal-4292986184-line-2)">&#160;[</text><text class="terminal-4292986184-r4" x="268.4" y="68.8" textLength="85.4" clip-path="url(#terminal-4292986184-line-2)">OPTIONS</text><text class="terminal-4292986184-r1" x="353.8" y="68.8" textLength="24.4" clip-path="url(#terminal-4292986184-line-2)">]&#160;</text><text class="terminal-4292986184-r4" x="378.2" y="68.8" textLength="85.4" clip-path="url(#terminal-4292986184-line-2)">COMMAND</text><text class="terminal-4292986184-r1" x="463.6" y="68.8" textLength="24.4" clip-path="url(#terminal-4292986184-line-2)">&#160;[</text><text class="terminal-4292986184-r4" x="488" y="68.8" textLength="48.8" clip-path="url(#terminal-4292986184-line-2)">ARGS</text><text class="terminal-4292986184-r1" x="536.8" y="68.8" textLength="439.2" clip-path="url(#terminal-4292986184-line-2)">]...&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-4292986184-line-2)">
-</text><text class="terminal-4292986184-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-4292986184-line-3)">
-</text><text class="terminal-4292986184-r1" x="0" y="117.6" textLength="976" clip-path="url(#terminal-4292986184-line-4)">&#160;A&#160;demo&#160;CLI.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-4292986184-line-4)">
-</text><text class="terminal-4292986184-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-4292986184-line-5)">
-</text><text class="terminal-4292986184-r5" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-4292986184-line-6)">╭─</text><text class="terminal-4292986184-r5" x="24.4" y="166.4" textLength="109.8" clip-path="url(#terminal-4292986184-line-6)">&#160;Options&#160;</text><text class="terminal-4292986184-r5" x="134.2" y="166.4" textLength="817.4" clip-path="url(#terminal-4292986184-line-6)">───────────────────────────────────────────────────────────────────</text><text class="terminal-4292986184-r5" x="951.6" y="166.4" textLength="24.4" clip-path="url(#terminal-4292986184-line-6)">─╮</text><text class="terminal-4292986184-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-4292986184-line-6)">
-</text><text class="terminal-4292986184-r5" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-4292986184-line-7)">│</text><text class="terminal-4292986184-r4" x="24.4" y="190.8" textLength="134.2" clip-path="url(#terminal-4292986184-line-7)">--verbose&#160;&#160;</text><text class="terminal-4292986184-r6" x="183" y="190.8" textLength="24.4" clip-path="url(#terminal-4292986184-line-7)">-v</text><text class="terminal-4292986184-r1" x="207.4" y="190.8" textLength="756.4" clip-path="url(#terminal-4292986184-line-7)">&#160;&#160;Enable&#160;verbose&#160;output.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r5" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-4292986184-line-7)">│</text><text class="terminal-4292986184-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-4292986184-line-7)">
-</text><text class="terminal-4292986184-r5" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-4292986184-line-8)">│</text><text class="terminal-4292986184-r4" x="24.4" y="215.2" textLength="134.2" clip-path="url(#terminal-4292986184-line-8)">--help-json</text><text class="terminal-4292986184-r1" x="158.6" y="215.2" textLength="805.2" clip-path="url(#terminal-4292986184-line-8)">&#160;&#160;&#160;&#160;&#160;&#160;Print&#160;this&#160;command&#x27;s&#160;help/usage&#160;as&#160;JSON.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r5" x="963.8" y="215.2" textLength="12.2" clip-path="url(#terminal-4292986184-line-8)">│</text><text class="terminal-4292986184-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-4292986184-line-8)">
-</text><text class="terminal-4292986184-r5" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-4292986184-line-9)">│</text><text class="terminal-4292986184-r4" x="24.4" y="239.6" textLength="134.2" clip-path="url(#terminal-4292986184-line-9)">--help&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r1" x="158.6" y="239.6" textLength="805.2" clip-path="url(#terminal-4292986184-line-9)">&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r5" x="963.8" y="239.6" textLength="12.2" clip-path="url(#terminal-4292986184-line-9)">│</text><text class="terminal-4292986184-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-4292986184-line-9)">
-</text><text class="terminal-4292986184-r5" x="0" y="264" textLength="976" clip-path="url(#terminal-4292986184-line-10)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-4292986184-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-4292986184-line-10)">
-</text><text class="terminal-4292986184-r5" x="0" y="288.4" textLength="24.4" clip-path="url(#terminal-4292986184-line-11)">╭─</text><text class="terminal-4292986184-r5" x="24.4" y="288.4" textLength="122" clip-path="url(#terminal-4292986184-line-11)">&#160;Commands&#160;</text><text class="terminal-4292986184-r5" x="146.4" y="288.4" textLength="805.2" clip-path="url(#terminal-4292986184-line-11)">──────────────────────────────────────────────────────────────────</text><text class="terminal-4292986184-r5" x="951.6" y="288.4" textLength="24.4" clip-path="url(#terminal-4292986184-line-11)">─╮</text><text class="terminal-4292986184-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-4292986184-line-11)">
-</text><text class="terminal-4292986184-r5" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-4292986184-line-12)">│</text><text class="terminal-4292986184-r4" x="24.4" y="312.8" textLength="195.2" clip-path="url(#terminal-4292986184-line-12)">db&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r1" x="231.8" y="312.8" textLength="732" clip-path="url(#terminal-4292986184-line-12)">&#160;Manage&#160;the&#160;database.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r5" x="963.8" y="312.8" textLength="12.2" clip-path="url(#terminal-4292986184-line-12)">│</text><text class="terminal-4292986184-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-4292986184-line-12)">
-</text><text class="terminal-4292986184-r5" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-4292986184-line-13)">│</text><text class="terminal-4292986184-r4" x="24.4" y="337.2" textLength="195.2" clip-path="url(#terminal-4292986184-line-13)">hello&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r1" x="231.8" y="337.2" textLength="732" clip-path="url(#terminal-4292986184-line-13)">&#160;Greet&#160;someone.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4292986184-r5" x="963.8" y="337.2" textLength="12.2" clip-path="url(#terminal-4292986184-line-13)">│</text><text class="terminal-4292986184-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-4292986184-line-13)">
-</text><text class="terminal-4292986184-r5" x="0" y="361.6" textLength="976" clip-path="url(#terminal-4292986184-line-14)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-4292986184-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-4292986184-line-14)">
+    <g class="terminal-3840462070-matrix">
+    <text class="terminal-3840462070-r1" x="0" y="20" textLength="341.6" clip-path="url(#terminal-3840462070-line-0)">$&#160;python&#160;help_json.py&#160;--help</text><text class="terminal-3840462070-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3840462070-line-0)">
+</text><text class="terminal-3840462070-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3840462070-line-1)">
+</text><text class="terminal-3840462070-r2" x="12.2" y="68.8" textLength="73.2" clip-path="url(#terminal-3840462070-line-2)">Usage:</text><text class="terminal-3840462070-r3" x="97.6" y="68.8" textLength="146.4" clip-path="url(#terminal-3840462070-line-2)">help_json.py</text><text class="terminal-3840462070-r1" x="244" y="68.8" textLength="24.4" clip-path="url(#terminal-3840462070-line-2)">&#160;[</text><text class="terminal-3840462070-r4" x="268.4" y="68.8" textLength="85.4" clip-path="url(#terminal-3840462070-line-2)">OPTIONS</text><text class="terminal-3840462070-r1" x="353.8" y="68.8" textLength="24.4" clip-path="url(#terminal-3840462070-line-2)">]&#160;</text><text class="terminal-3840462070-r4" x="378.2" y="68.8" textLength="85.4" clip-path="url(#terminal-3840462070-line-2)">COMMAND</text><text class="terminal-3840462070-r1" x="463.6" y="68.8" textLength="24.4" clip-path="url(#terminal-3840462070-line-2)">&#160;[</text><text class="terminal-3840462070-r4" x="488" y="68.8" textLength="48.8" clip-path="url(#terminal-3840462070-line-2)">ARGS</text><text class="terminal-3840462070-r1" x="536.8" y="68.8" textLength="439.2" clip-path="url(#terminal-3840462070-line-2)">]...&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3840462070-line-2)">
+</text><text class="terminal-3840462070-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3840462070-line-3)">
+</text><text class="terminal-3840462070-r1" x="0" y="117.6" textLength="976" clip-path="url(#terminal-3840462070-line-4)">&#160;A&#160;demo&#160;CLI.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3840462070-line-4)">
+</text><text class="terminal-3840462070-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3840462070-line-5)">
+</text><text class="terminal-3840462070-r5" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-3840462070-line-6)">╭─</text><text class="terminal-3840462070-r5" x="24.4" y="166.4" textLength="109.8" clip-path="url(#terminal-3840462070-line-6)">&#160;Options&#160;</text><text class="terminal-3840462070-r5" x="134.2" y="166.4" textLength="817.4" clip-path="url(#terminal-3840462070-line-6)">───────────────────────────────────────────────────────────────────</text><text class="terminal-3840462070-r5" x="951.6" y="166.4" textLength="24.4" clip-path="url(#terminal-3840462070-line-6)">─╮</text><text class="terminal-3840462070-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3840462070-line-6)">
+</text><text class="terminal-3840462070-r5" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3840462070-line-7)">│</text><text class="terminal-3840462070-r4" x="24.4" y="190.8" textLength="134.2" clip-path="url(#terminal-3840462070-line-7)">--verbose&#160;&#160;</text><text class="terminal-3840462070-r6" x="183" y="190.8" textLength="24.4" clip-path="url(#terminal-3840462070-line-7)">-v</text><text class="terminal-3840462070-r1" x="207.4" y="190.8" textLength="756.4" clip-path="url(#terminal-3840462070-line-7)">&#160;&#160;Enable&#160;verbose&#160;output.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r5" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3840462070-line-7)">│</text><text class="terminal-3840462070-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3840462070-line-7)">
+</text><text class="terminal-3840462070-r5" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-3840462070-line-8)">│</text><text class="terminal-3840462070-r4" x="24.4" y="215.2" textLength="134.2" clip-path="url(#terminal-3840462070-line-8)">--help-json</text><text class="terminal-3840462070-r1" x="158.6" y="215.2" textLength="805.2" clip-path="url(#terminal-3840462070-line-8)">&#160;&#160;&#160;&#160;&#160;&#160;Print&#160;this&#160;command&#x27;s&#160;help/usage&#160;as&#160;JSON.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r5" x="963.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3840462070-line-8)">│</text><text class="terminal-3840462070-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3840462070-line-8)">
+</text><text class="terminal-3840462070-r5" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3840462070-line-9)">│</text><text class="terminal-3840462070-r4" x="24.4" y="239.6" textLength="134.2" clip-path="url(#terminal-3840462070-line-9)">--help&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r1" x="158.6" y="239.6" textLength="805.2" clip-path="url(#terminal-3840462070-line-9)">&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r5" x="963.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3840462070-line-9)">│</text><text class="terminal-3840462070-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3840462070-line-9)">
+</text><text class="terminal-3840462070-r5" x="0" y="264" textLength="976" clip-path="url(#terminal-3840462070-line-10)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3840462070-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3840462070-line-10)">
+</text><text class="terminal-3840462070-r5" x="0" y="288.4" textLength="24.4" clip-path="url(#terminal-3840462070-line-11)">╭─</text><text class="terminal-3840462070-r5" x="24.4" y="288.4" textLength="122" clip-path="url(#terminal-3840462070-line-11)">&#160;Commands&#160;</text><text class="terminal-3840462070-r5" x="146.4" y="288.4" textLength="805.2" clip-path="url(#terminal-3840462070-line-11)">──────────────────────────────────────────────────────────────────</text><text class="terminal-3840462070-r5" x="951.6" y="288.4" textLength="24.4" clip-path="url(#terminal-3840462070-line-11)">─╮</text><text class="terminal-3840462070-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3840462070-line-11)">
+</text><text class="terminal-3840462070-r5" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3840462070-line-12)">│</text><text class="terminal-3840462070-r4" x="24.4" y="312.8" textLength="195.2" clip-path="url(#terminal-3840462070-line-12)">db&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r1" x="231.8" y="312.8" textLength="732" clip-path="url(#terminal-3840462070-line-12)">&#160;Manage&#160;the&#160;database.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r5" x="963.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3840462070-line-12)">│</text><text class="terminal-3840462070-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3840462070-line-12)">
+</text><text class="terminal-3840462070-r5" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-3840462070-line-13)">│</text><text class="terminal-3840462070-r4" x="24.4" y="337.2" textLength="195.2" clip-path="url(#terminal-3840462070-line-13)">hello&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r1" x="231.8" y="337.2" textLength="732" clip-path="url(#terminal-3840462070-line-13)">&#160;Greet&#160;someone.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3840462070-r5" x="963.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3840462070-line-13)">│</text><text class="terminal-3840462070-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3840462070-line-13)">
+</text><text class="terminal-3840462070-r5" x="0" y="361.6" textLength="976" clip-path="url(#terminal-3840462070-line-14)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3840462070-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3840462070-line-14)">
+</text><text class="terminal-3840462070-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3840462070-line-15)">
 </text>
     </g>
     </g>

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -318,8 +318,10 @@ def list_themes(ctx: RichContext, param: click.Parameter, value: bool) -> None:
 @_rich_option(
     "--output",
     "-o",
-    type=click.Choice(["html", "svg", "text"], case_sensitive=False),
-    help="Optionally render help text as HTML or SVG or plain text. By default, help text is rendered normally.",
+    type=click.Choice(["html", "svg", "text", "json"], case_sensitive=False),
+    help="Optionally render help text as HTML, SVG, plain text, or machine-readable JSON."
+    " By default, help text is rendered normally. With [de]json[/], a plain [option]--help[/] emits"
+    " the [de]--help-json[/] schema; combine [de]--output svg[/] with [option]--help-json[/] to export the JSON.",
 )
 @_rich_option(
     "--errors-in-output-format",
@@ -375,7 +377,7 @@ def main(
     ctx: RichContext,
     script_and_args: Tuple[str, ...],
     theme: str,
-    output: Literal[None, "html", "svg"],
+    output: Literal[None, "html", "svg", "text", "json"],
     errors_in_output_format: bool,
     suppress_warnings: bool,
     patch_rich_click: bool,

--- a/src/rich_click/help_json.py
+++ b/src/rich_click/help_json.py
@@ -234,7 +234,22 @@ def build_help_json_option(
         if not value or ctx.resilient_parsing:
             return
         # Delegate to the command so the get_help_json/format_help_json overrides take effect.
-        click.echo(ctx.command.get_help_json(ctx))  # type: ignore[attr-defined]
+        text = ctx.command.get_help_json(ctx)  # type: ignore[attr-defined]
+        export_as = getattr(ctx, "export_console_as", None)
+        if export_as in ("html", "svg", "text"):
+            # The rich-click CLI's --output html/svg/text: render the JSON through the
+            # recording console so it can be exported (e.g. an SVG screenshot of the schema),
+            # matching how regular --help honors --output.
+            from rich.json import JSON
+
+            from rich_click.rich_context import RichContext
+
+            assert isinstance(ctx, RichContext)  # export_console_as is only ever set on a RichContext
+            formatter = ctx.make_formatter()
+            formatter.console.print(JSON(text))
+            click.echo(formatter.getvalue())
+        else:
+            click.echo(text)
         ctx.exit()
 
     return RichOption(

--- a/src/rich_click/rich_command.py
+++ b/src/rich_click/rich_command.py
@@ -377,6 +377,18 @@ class RichCommand(Command):
             self._help_json_option = build_help_json_option(names)
         return self._help_json_option
 
+    def get_help(self, ctx: click.Context) -> str:
+        """
+        Return the command's help as a string.
+
+        When the context requests JSON output (``export_console_as == "json"``, set by the
+        rich-click CLI's ``--output json``), the machine-readable ``--help-json`` schema is
+        returned instead of the rendered help text, so a plain ``--help`` yields JSON.
+        """
+        if getattr(ctx, "export_console_as", None) == "json":
+            return self.get_help_json(cast(RichContext, ctx))
+        return super().get_help(ctx)
+
     def get_help_json(self, ctx: "RichContext") -> str:
         """
         Return this command's help as a machine-readable JSON string.

--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -20,7 +20,7 @@ class RichContext(click.Context):
 
     formatter_class: Type[RichHelpFormatter] = RichHelpFormatter
     console: Optional["Console"] = None
-    export_console_as: Optional[Literal["html", "svg", "text"]] = None
+    export_console_as: Optional[Literal["html", "svg", "text", "json"]] = None
     errors_in_output_format: bool = False
     help_to_stderr: bool = False
     help_json_option_names: Optional[List[str]] = None
@@ -30,7 +30,7 @@ class RichContext(click.Context):
         *args: Any,
         rich_console: Optional["Console"] = None,
         rich_help_config: Optional[Union[Mapping[str, Any], RichHelpConfiguration]] = None,
-        export_console_as: Optional[Literal["html", "svg", "text"]] = None,
+        export_console_as: Optional[Literal["html", "svg", "text", "json"]] = None,
         errors_in_output_format: Optional[bool] = None,
         help_to_stderr: Optional[bool] = None,
         help_json_option_names: Optional[List[str]] = None,

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -116,7 +116,7 @@ class RichHelpFormatter(click.HelpFormatter):
     This console is meant only for use with the formatter and should
     not be created directly
     """
-    export_console_as: Literal[None, "html", "svg", "text"] = None
+    export_console_as: Literal[None, "html", "svg", "text", "json"] = None
 
     option_panel_class: Type[RichOptionPanel] = RichOptionPanel
     command_panel_class: Type[RichCommandPanel] = RichCommandPanel
@@ -129,7 +129,7 @@ class RichHelpFormatter(click.HelpFormatter):
         *args: Any,
         console: Optional["Console"] = None,
         config: Optional[RichHelpConfiguration] = None,
-        export_console_as: Literal[None, "html", "svg", "text"] = None,
+        export_console_as: Literal[None, "html", "svg", "text", "json"] = None,
         export_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
@@ -317,7 +317,9 @@ class RichHelpFormatter(click.HelpFormatter):
         elif self.console.record:
             kw = self.export_kwargs.copy()
             kw.setdefault("clear", False)
-            if self.export_console_as == "text" or self.export_console_as is None:
+            if self.export_console_as in ("text", "json") or self.export_console_as is None:
+                # "json" is a help-content mode, not a console export; treat any stray
+                # console output (e.g. errors) as plain text rather than raising below.
                 res = self.console.export_text(**kw)
             elif self.export_console_as == "html":
                 kw.setdefault("inline_styles", True)

--- a/tests/test_rich_click_cli.py
+++ b/tests/test_rich_click_cli.py
@@ -129,15 +129,19 @@ def test_rich_click_cli_help_with_rich_config_from_file(tmp_path: Path) -> None:
 │ --help     -h  Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Custom Name ────────────────────────────────────────────────────────────────────────────────────╮
-│ --theme        -t  THEME            Set the theme to render the CLI with.                        │
-│ --rich-config  -c  JSON             Keyword arguments to pass into the RichHelpConfiguration()   │
-│                                     used to render the help text of the command. You can pass    │
-│                                     either a JSON directly, or a file prefixed with `@` (for     │
-│                                     example: '@rich_config.json'). Note that the --rich-config   │
-│                                     option is also used to render this help text you're reading  │
-│                                     right now!                                                   │
-│ --output       -o  [html|svg|text]  Optionally render help text as HTML or SVG or plain text. By │
-│                                     default, help text is rendered normally.                     │
+│ --theme        -t  THEME                 Set the theme to render the CLI with.                   │
+│ --rich-config  -c  JSON                  Keyword arguments to pass into the                      │
+│                                          RichHelpConfiguration() used to render the help text of │
+│                                          the command. You can pass either a JSON directly, or a  │
+│                                          file prefixed with `@` (for example:                    │
+│                                          '@rich_config.json'). Note that the --rich-config       │
+│                                          option is also used to render this help text you're     │
+│                                          reading right now!                                      │
+│ --output       -o  [html|svg|text|json]  Optionally render help text as HTML, SVG, plain text,   │
+│                                          or machine-readable JSON. By default, help text is      │
+│                                          rendered normally. With json, a plain --help emits the  │
+│                                          --help-json schema; combine --output svg with           │
+│                                          --help-json to export the JSON.                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )
@@ -878,3 +882,77 @@ def test_cli_output_text(mock_script_writer: Callable[[str], Path]) -> None:
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 """
     )
+
+
+@pytest.fixture
+def group_script(mock_script_writer: WriteScript) -> Path:
+    return mock_script_writer(
+        '''
+        import rich_click as click
+
+        @click.group()
+        @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output.")
+        def cli(verbose):
+            """A demo CLI."""
+
+        @cli.command()
+        @click.option("--count", type=int, default=1, help="Number of greetings.")
+        @click.argument("name")
+        def hello(count, name):
+            """Greet someone."""
+        '''
+    )
+
+
+def test_cli_output_json(group_script: Path) -> None:
+    # `--output json` makes a plain `--help` emit the machine-readable --help-json schema.
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "--output", "json", "mymodule:cli", "--help"],
+    )
+    assert res.returncode == 0
+
+    schema = json.loads(res.stdout.decode())
+    assert schema["name"] == "cli"
+    assert schema["help"] == "A demo CLI."
+    param_opts = [opt for param in schema["params"] for opt in param["opts"]]
+    assert "--verbose" in param_opts
+    assert "--help" not in param_opts  # meta-options are excluded
+    assert schema["subcommands"] == {"hello": {"help": "Greet someone."}}
+
+
+def test_cli_output_json_subcommand(group_script: Path) -> None:
+    # `--output json` works at any command level, like `--help` itself.
+    res = run_as_subprocess(
+        [sys.executable, "-m", "src.rich_click", "-o", "json", "mymodule:cli", "hello", "--help"],
+    )
+    assert res.returncode == 0
+
+    schema = json.loads(res.stdout.decode())
+    assert schema["name"] == "hello"
+    by_name = {param["name"]: param for param in schema["params"]}
+    assert by_name["count"]["default"] == 1
+    assert by_name["name"]["kind"] == "argument"
+    assert "subcommands" not in schema
+
+
+def test_cli_output_svg_with_help_json(group_script: Path) -> None:
+    # `--help-json` honors `--output`, so the JSON schema can be exported as e.g. an SVG.
+    res = run_as_subprocess(
+        [
+            sys.executable,
+            "-m",
+            "src.rich_click",
+            "-c",
+            '{"help_json": true}',
+            "--output",
+            "svg",
+            "mymodule:cli",
+            "--help-json",
+        ],
+    )
+    assert res.returncode == 0
+
+    out = res.stdout.decode()
+    assert out.startswith('<svg class="rich-terminal"')
+    # The rendered SVG carries the schema's content (e.g. the command name from the JSON).
+    assert "cli" in out


### PR DESCRIPTION
Stacked on top of #331 (base branch `help-json`). Implements dwreeves's CLI suggestion from that review.

## What

Extends the rich-click CLI's `--output` option with a `json` value, so machine-readable help works through the CLI wrapper for *any* Click CLI — even ones that haven't opted into `help_json`.

```console
$ rich-click --output=json flask --help
{ "name": "flask", "path": "flask", ... }
```

Two behaviours:

1. **`rich-click --output=json [cmd] --help`** emits the `--help-json` schema instead of rendered help. A plain `--help` yields JSON — no need for the target to enable `help_json`. Implemented via a `RichCommand.get_help()` override that returns `get_help_json()` when the context's `export_console_as` is `"json"`.
2. **`--output` applies to the `--help-json` flag too.** The schema is rendered through the recording console and exported, so `rich-click -c '{"help_json": true}' --output=svg [cmd] --help-json` produces an SVG of the JSON (dwreeves's second case).

## Why `--output json`, not `--json`

It's a *value* of the existing `-o`/`--output` option, not a new flag. The wrapper consumes `--output` before the script args (`allow_interspersed_args=False`), so the wrapped command never sees it — no risk of clashing with the target's own options.

## Notes

- `getvalue()` treats `"json"` as plain-text export defensively; it should never reach there for help, since `get_help` short-circuits.
- Docs updated (`rich_click_cli.md`, cross-ref from `machine_readable_help.md`); 3 new tests + regenerated `--help` snapshot.

⚠️ Review/merge #331 first — this is stacked on it, so the diff will look correct once the base lands on `main`.