### PR TITLE
Fix ctx.forward() to rich commands failing when patching

### DIFF
--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional, Type, Union
 
 import click
+from click.core import augment_usage_errors
 from click.globals import get_current_context as click_get_current_context
 
 from rich_click.rich_help_configuration import RichHelpConfiguration
@@ -13,6 +14,25 @@ if TYPE_CHECKING:  # pragma: no cover
     from types import TracebackType
 
     from rich.console import Console
+
+
+def _click_base_command_type() -> Type["click.Command"]:
+    """
+    Return the genuine ``click.Command`` class.
+
+    ``rich_click.patch.patch()`` rebinds ``click.Command`` /
+    ``click.core.Command`` to a rich-click subclass. Click's own
+    ``Context.forward`` / ``Context.invoke`` resolve the bare name ``Command``
+    from ``click.core`` at call time and use it in an ``isinstance`` guard, so
+    after patching that guard is narrowed to the subclass and rejects genuine
+    Click commands that are not that exact subclass (e.g. ``RichCommand``
+    instances or commands defined before ``patch()`` ran). Walk the MRO so we
+    always recover the real base class even when ``click.Command`` is patched.
+    """
+    for klass in click.Command.__mro__:
+        if klass.__module__ == "click.core" and klass.__name__ == "Command":
+            return klass
+    return click.Command
 
 
 class RichContext(click.Context):
@@ -99,6 +119,58 @@ class RichContext(click.Context):
             export_console_as=(self.export_console_as if not error_mode or self.errors_in_output_format else None),
         )
         return formatter
+
+    def forward(self, __cmd: "click.Command", *args: Any, **kwargs: Any) -> Any:
+        """
+        Forward to another command, tolerant of ``patch()``.
+
+        Mirrors ``click.Context.forward`` but validates against the genuine
+        ``click.Command`` base class so forwarding keeps working after
+        ``rich_click.patch.patch()`` rebinds ``click.Command`` to a subclass.
+        """
+        if not isinstance(__cmd, _click_base_command_type()):
+            raise TypeError("Callback is not a command.")
+
+        for param in self.params:
+            if param not in kwargs:
+                kwargs[param] = self.params[param]
+
+        return self.invoke(__cmd, *args, **kwargs)
+
+    def invoke(self, __callback: Any, *args: Any, **kwargs: Any) -> Any:
+        """
+        Invoke a command/callback, tolerant of ``patch()``.
+
+        ``click.Context.invoke`` decides whether its first argument is a command
+        via ``isinstance(arg, click.Command)``. After ``patch()`` narrows
+        ``click.Command`` to a subclass, genuine Click commands that are not that
+        exact subclass fall through to the raw-callback branch and get called as
+        ``cmd(**params)``, which is wrong. Detect that case and run Click's
+        command dispatch against the real base class; delegate everything else
+        unchanged.
+        """
+        base_command = _click_base_command_type()
+        if isinstance(__callback, base_command) and not isinstance(__callback, click.Command):
+            other_cmd = __callback
+            if other_cmd.callback is None:
+                raise TypeError("The given command does not have a callback that can be invoked.")
+            callback = other_cmd.callback
+
+            ctx = self._make_sub_context(other_cmd)
+
+            for param in other_cmd.params:
+                if param.name not in kwargs and param.expose_value:
+                    kwargs[param.name] = param.type_cast_value(ctx, param.get_default(ctx))
+
+            # Track all kwargs as params, so that forward() will pass
+            # them on in subsequent calls.
+            ctx.params.update(kwargs)
+
+            with augment_usage_errors(self):
+                with ctx:
+                    return callback(*args, **kwargs)
+
+        return super().invoke(__callback, *args, **kwargs)
 
     if TYPE_CHECKING:  # pragma: no cover
 

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,0 +1,98 @@
+# ruff: noqa: D103,E501
+import sys
+
+from tests.conftest import WriteScript, run_as_subprocess
+
+
+def test_patch_ctx_forward_to_rich_command(mock_script_writer: WriteScript) -> None:
+    # Regression test for https://github.com/ewels/rich-click/issues/338
+    #
+    # patch() rebinds click.Command to a rich-click subclass, which narrowed the
+    # isinstance guard in click's Context.forward/invoke and broke
+    # ctx.forward(rich_cmd). Run in a subprocess because patch() mutates global
+    # Click state.
+    scripts = mock_script_writer(
+        """
+        import sys
+
+        import click
+        from click.testing import CliRunner
+
+        from rich_click.patch import patch
+
+        patch()
+
+        import rich_click
+
+
+        @rich_click.command()
+        @click.option("--name", default="world")
+        @click.option("--count", default=1)
+        def target(name, count):
+            for _ in range(count):
+                click.echo(f"hello {name}")
+
+
+        @click.command()
+        @click.option("--name", default="world")
+        @click.option("--count", default=1)
+        @click.pass_context
+        def source(ctx, name, count):
+            ctx.forward(target)
+
+
+        if __name__ == "__main__":
+            result = CliRunner().invoke(source, ["--name", "alice", "--count", "2"])
+            if result.exception is not None and not isinstance(result.exception, SystemExit):
+                raise result.exception
+            assert result.exit_code == 0, result.output
+            sys.stdout.write(result.output)
+        """,
+    )
+
+    res = run_as_subprocess([sys.executable, (scripts / "mymodule.py").as_posix()])
+    assert res.returncode == 0, res.stderr.decode()
+    assert res.stdout.decode() == "hello alice\nhello alice\n"
+
+
+def test_patch_ctx_forward_to_command_defined_before_patch(mock_script_writer: WriteScript) -> None:
+    # Commands created before patch() are genuine click.Command instances and
+    # must still be forwardable once patch() runs.
+    scripts = mock_script_writer(
+        """
+        import sys
+
+        import click
+        from click.testing import CliRunner
+
+
+        @click.command()
+        @click.option("--name", default="world")
+        def target(name):
+            click.echo(f"hi {name}")
+
+
+        from rich_click.patch import patch
+
+        patch()
+
+
+        @click.command()
+        @click.option("--name", default="world")
+        @click.pass_context
+        def source(ctx, name):
+            ctx.forward(target)
+
+
+        if __name__ == "__main__":
+            result = CliRunner().invoke(source, ["--name", "bob"])
+            if result.exception is not None and not isinstance(result.exception, SystemExit):
+                raise result.exception
+            assert result.exit_code == 0, result.output
+            sys.stdout.write(result.output)
+        """,
+    )
+
+    res = run_as_subprocess([sys.executable, (scripts / "mymodule.py").as_posix()])
+    assert res.returncode == 0, res.stderr.decode()
+    assert res.stdout.decode() == "hi bob\n"


### PR DESCRIPTION
## Summary

Fixes #338.

After `rich_click.patch.patch()`, calling `ctx.forward(rich_cmd)` raised:

```
TypeError: Callback is not a command.
```

### Root cause

`patch()` rebinds `click.Command` / `click.core.Command` to a rich-click
subclass (`_PatchedRichCommand`). Click's own `Context.forward` /
`Context.invoke` resolve the bare name `Command` from `click.core` at call
time and use it in an `isinstance` guard:

```python
# click/core.py
def forward(__self, __cmd, *args, **kwargs):
    if not isinstance(__cmd, Command):   # Command == _PatchedRichCommand after patch()
        raise TypeError("Callback is not a command.")
```

Because the patched class is a *subclass*, the guard is narrowed: any genuine
Click command that is not that exact subclass fails the check. This affects
`RichCommand` instances built via `rich_click.command()`, plain `click.Command`
objects created before `patch()` ran, and third-party commands. `invoke()` has
the same narrowed check and would otherwise mis-dispatch the command as a raw
callback (`cmd(**params)`).

### Fix

Override `forward` / `invoke` on `RichContext` to validate against the genuine
`click.Command` base class, recovered by walking `click.Command.__mro__` so it
still works while `click.Command` is patched. When unpatched, `click.Command`
*is* the genuine base, so behavior is identical (both overrides delegate to
`super()`), and `super().invoke()` still handles all normal command dispatch.

### Tests

Added `tests/test_patch.py` with subprocess-based regression tests (patching
mutates global Click state), covering:

- `ctx.forward()` to a `rich_click.command()` command under `patch()`
- `ctx.forward()` to a base `click.Command` created before `patch()` ran

Both fail on `main` with the exact `TypeError` from the issue and pass with the
fix. `ruff check`, `ruff format`, and `mypy` are clean on the changed files.
