### PR TITLE
Misc. dev cleanup

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,7 +28,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv pip install ".[docs]"
+        run: uv pip install --group docs .
 
       - name: Generate terminal images with rich-codex
         if: github.repository_owner == 'ewels' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,7 +28,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv pip install --group docs .
+        run: uv sync --active --group docs
 
       - name: Generate terminal images with rich-codex
         if: github.repository_owner == 'ewels' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
           activate-environment: true
       - name: Install dependencies
         run:  |
-          uv pip install ".[dev]"
+          uv pip install --group dev .
           uv pip install "mypy<1.16"  # later versions don't work with python 3.8
       - name: Run pre-commit
         run: pre-commit run -a

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,6 @@ jobs:
           python-version: 3
           activate-environment: true
       - name: Install dependencies
-        run:  |
-          uv pip install --group dev .
+        run: uv sync --active
       - name: Run prek
         run: prek run -a

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,6 +22,5 @@ jobs:
       - name: Install dependencies
         run:  |
           uv pip install --group dev .
-          uv pip install "mypy<1.16"  # later versions don't work with python 3.8
-      - name: Run pre-commit
-        run: pre-commit run -a
+      - name: Run prek
+        run: prek run -a

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -52,14 +52,15 @@ jobs:
           python-version: ${{ matrix.python }}
           activate-environment: true
 
-      - name: Install dependencies
+      - name: Run tests
         run: |
-          uv pip install --group dev .
-          uv pip install --upgrade "click==$CLICK_VERSION" "rich==$RICH_VERSION" "typer==$TYPER_VERSION" --prerelease=allow
+          uv run \
+            --with "click==$CLICK_VERSION" \
+            --with "rich==$RICH_VERSION" \
+            --with "typer==$TYPER_VERSION" \
+            --prerelease=allow \
+            pytest --cov --cov-report term
         env:
           CLICK_VERSION: ${{ matrix.click }}
           RICH_VERSION: ${{ matrix.rich }}
           TYPER_VERSION: ${{ matrix.typer }}
-
-      - name: Run tests
-        run: pytest --cov --cov-report term

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install ".[dev]"
+          uv pip install --group dev .
           uv pip install --upgrade "click==$CLICK_VERSION" "rich==$RICH_VERSION" "typer==$TYPER_VERSION" --prerelease=allow
         env:
           CLICK_VERSION: ${{ matrix.click }}

--- a/.github/workflows/rich-codex.yml
+++ b/.github/workflows/rich-codex.yml
@@ -21,7 +21,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv pip install ".[docs]"
+        run: uv pip install --group docs .
 
       - name: Generate terminal images with rich-codex
         uses: ewels/rich-codex@80de9de011c994f32274bb4cffee140567621d8e # v1.2.11

--- a/.github/workflows/rich-codex.yml
+++ b/.github/workflows/rich-codex.yml
@@ -21,7 +21,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv pip install --group docs .
+        run: uv sync --active --no-default-groups --group docs
 
       - name: Generate terminal images with rich-codex
         uses: ewels/rich-codex@80de9de011c994f32274bb4cffee140567621d8e # v1.2.11

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --prerelease allow ".[dev]"
+          uv pip install --prerelease allow --group dev .
 
       - name: Run tests
         run: pytest --cov --cov-report term

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -27,9 +27,5 @@ jobs:
           python-version: ${{ matrix.python }}
           activate-environment: true
 
-      - name: Install dependencies
-        run: |
-          uv pip install --prerelease allow --group dev .
-
       - name: Run tests
-        run: pytest --cov --cov-report term
+        run: uv run --prerelease=allow pytest --cov --cov-report term

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -27,17 +27,15 @@ jobs:
           python-version: ${{ matrix.python }}
           activate-environment: true
 
-      - name: Install dependencies
-        run: |
-          uv pip install --editable "."
-          uv pip install --upgrade "click==$CLICK_VERSION"
-        env:
-          CLICK_VERSION: ${{ matrix.click }}
-
       - name: Test examples
         run: |
           for f in examples/*py
           do
             echo -e "\n\n$f"
-            python "${f}" --help || exit 1;
+            uv run \
+              --no-default-groups \
+              --with "click==$CLICK_VERSION" \
+              python "${f}" --help || exit 1;
           done
+        env:
+          CLICK_VERSION: ${{ matrix.click }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,29 +13,24 @@ repos:
 #      - id: prettier
 
   - repo: https://github.com/rhysd/actionlint
-    rev: 03d0035246f3e81f36aed592ffb4bebf33a03106  # frozen: v1.7.7
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
     hooks:
       - id: actionlint
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 91d98438175bd32e4eb14a22e50a3ec0f9e55466  # frozen: v2.2.4
+    rev: b82a24a520c5d496cb7b23b4e9b63537c280f51b  # frozen: v2.27.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 73b0f6d59bbfcb75e17a4653d581c9dfaca13969  # frozen: v0.12.5
+    rev: 7c55798a78262d14b2074abf623d8a992ebb70d4  # frozen: v0.16.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         name: Ruff
         args: [--fix]
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: a4920527036bb9a3f3e6055d595849d67d0da066  # frozen: 25.1.0
-    hooks:
-      - id: black
-        language_version: python3.12
-        exclude: ^docs/
+      - id: ruff-format
+        name: Ruff format
 
   - repo: local
     hooks:
@@ -49,7 +44,7 @@ repos:
         require_serial: true
 
   - repo: https://github.com/codespell-project/codespell
-    rev: 63c8f8312b7559622c0d82815639671ae42132ac  # frozen: v2.4.1
+    rev: 57b21406f092110c18776e39b0bda50d37c945c8  # frozen: v2.4.3
     hooks:
     - id: codespell
       files: ^docs/.*\.md$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Requirements:
 uv python pin 3.13
 uv venv .venv
 source .venv/bin/activate
-uv sync --extra dev
+uv sync --all-groups
 pre-commit install
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ scripts.rich-click = "rich_click.cli:main"
 dev = [
     "inline-snapshot>=0.24",
     "jsonschema>=4",
-    "mypy>=2.3",
+    "mypy>=2.3; python_version>='3.10'",
     "nodeenv>=1.9.1",
     "packaging>=25",
     "prek>=0.4.12",
@@ -80,7 +80,6 @@ docs = [
 dynamic.version = { attr = "rich_click.__version__" }
 
 [tool.uv]
-dependency-groups.dev = { requires-python = ">=3.10" }
 dependency-groups.docs = { requires-python = ">=3.13" }
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
     "version",
@@ -42,78 +44,6 @@ urls.Issues = "https://github.com/ewels/rich-click/issues"
 urls.Repository = "https://github.com/ewels/rich-click"
 scripts.rich-click = "rich_click.cli:main"
 
-[tool.setuptools.dynamic]
-version = { attr = "rich_click.__version__" }
-
-[tool.black]
-line-length = 120
-target-version = [ 'py37' ]
-
-[tool.ruff]
-line-length = 120
-exclude = [
-    ".git",
-    ".venv",
-    "__pycache__",
-    "build",
-    "docs/",
-    "examples/**",
-    "sdist",
-    "tests/fixtures/**",
-    "venv",
-]
-
-lint.select = [
-    "D",    # pydocstyle
-    "E",    # pycodestyle
-    "F",    # flake8
-    "I001", # isort
-    "W",    # pycodestyle
-]
-lint.ignore = [
-    "D100", # Missing docstring in public module
-    "D102", # Missing docstring in public method
-    "D105", # Missing docstring in magic method
-    "D203", # 1 blank line required before class docstring
-    "D205", # 1 blank line required between summary line and description
-    "D212", # Multi-line docstring summary should start at the first line
-    "E731", # Do not assign a lambda expression, use a def
-]
-lint.per-file-ignores."tests/**/*.py" = [
-    "D",
-]
-
-lint.isort.known-first-party = [ "rich_click" ]
-lint.isort.lines-after-imports = 2
-
-[tool.pyproject-fmt]
-indent = 4
-
-[tool.pytest.ini_options]
-addopts = "-s -rP -v --showlocals --cov --cov-report term"
-pythonpath = [ "tests", "src" ]
-testpaths = [ "tests" ]
-
-[tool.mypy]
-python_version = "3.10"
-scripts_are_modules = true
-strict = true
-follow_imports = "normal"
-exclude = [
-    '.*?live_style_editor\.py$',
-]
-
-[tool.pyright]
-include = [ "src" ]
-pythonVersion = "3.8"
-typeCheckingMode = "basic"
-executionEnvironments = [
-    { root = "src" },
-    { root = "tests", extra_paths = [
-        "src",
-    ] },
-]
-
 [dependency-groups]
 dev = [
     "inline-snapshot>=0.24",
@@ -121,11 +51,12 @@ dev = [
     "mypy>=1.14.1",
     "nodeenv>=1.9.1",                    # for --resolution=lowest support
     "packaging>=25",
-    "pre-commit>=3.5",
+    "prek>=0.4.12",
     "pytest>=8.3.5",
     "pytest-cov>=5",
     "rich-codex>=1.2.11",
     "ruff>=0.12.4",
+    "ty>=0.0.69",
     "typer>=0.15,<0.26",
     "types-setuptools>=75.8.0.20250110",
 ]
@@ -145,8 +76,76 @@ docs = [
     "typer>=0.15,<0.26",
 ]
 
+[tool.setuptools]
+dynamic.version = { attr = "rich_click.__version__" }
+
 [tool.uv]
 dependency-groups.docs = { requires-python = ">=3.13" }
+
+[tool.ruff]
+line-length = 120
+exclude = [
+    ".git",
+    ".venv",
+    "__pycache__",
+    "build",
+    "docs/",
+    "sdist",
+    "tests/fixtures/**",
+    "venv",
+]
+lint.select = [
+    "D",    # pydocstyle
+    "E",    # pycodestyle
+    "F",    # flake8
+    "I001", # isort
+    "W",    # pycodestyle
+]
+lint.ignore = [
+    "D100", # Missing docstring in public module
+    "D102", # Missing docstring in public method
+    "D105", # Missing docstring in magic method
+    "D203", # 1 blank line required before class docstring
+    "D205", # 1 blank line required between summary line and description
+    "D212", # Multi-line docstring summary should start at the first line
+    "E731", # Do not assign a lambda expression, use a def
+]
+lint.exclude = [
+    "examples/**",
+]
+lint.per-file-ignores."tests/**/*.py" = [
+    "D",
+]
+lint.isort.known-first-party = [ "rich_click" ]
+lint.isort.lines-after-imports = 2
+
+[tool.pyproject-fmt]
+indent = 4
+
+[tool.mypy]
+exclude = [
+    '.*?live_style_editor\.py$',
+]
+follow_imports = "normal"
+python_version = "3.10"
+strict = true
+scripts_are_modules = true
+
+[tool.pyright]
+pythonVersion = "3.8"
+typeCheckingMode = "basic"
+include = [ "src" ]
+executionEnvironments = [
+    { root = "src" },
+    { root = "tests", extra_paths = [
+        "src",
+    ] },
+]
+
+[tool.pytest]
+ini_options.testpaths = [ "tests" ]
+ini_options.pythonpath = [ "tests", "src" ]
+ini_options.addopts = "-s -rP -v --showlocals --cov --cov-report term"
 
 [tool.inline-snapshot]
 hash-length = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,35 +36,6 @@ dependencies = [
     "rich>=12",
     "typing-extensions>=4; python_version<'3.11'",
 ]
-optional-dependencies.dev = [
-    "inline-snapshot>=0.24",
-    "jsonschema>=4",                     # for --resolution=lowest support
-    "mypy>=1.14.1",
-    "nodeenv>=1.9.1",                    # for --resolution=lowest support
-    "packaging>=25",
-    "pre-commit>=3.5",
-    "pytest>=8.3.5",
-    "pytest-cov>=5",
-    "rich-codex>=1.2.11",
-    "ruff>=0.12.4",
-    "typer>=0.15,<0.26",
-    "types-setuptools>=75.8.0.20250110",
-]
-optional-dependencies.docs = [
-    "markdown-include>=0.8.1",
-    "mike>=2.1.3",
-    "mkdocs[docs]>=1.6.1",
-    "mkdocs-github-admonitions-plugin>=0.1.1",
-    "mkdocs-glightbox>=0.4",
-    "mkdocs-include-markdown-plugin>=7.1.7; python_version>='3.9'",
-    "mkdocs-material[imaging]~=9.5.18",
-    "mkdocs-material-extensions>=1.3.1",
-    "mkdocs-redirects>=1.2.2",
-    "mkdocs-rss-plugin>=1.15",
-    "mkdocstrings[python]>=0.26.1",
-    "rich-codex>=1.2.11",
-    "typer>=0.15,<0.26",
-]
 urls.Documentation = "https://github.com/ewels/rich-click"
 urls.Homepage = "https://github.com/ewels/rich-click"
 urls.Issues = "https://github.com/ewels/rich-click/issues"
@@ -142,6 +113,40 @@ executionEnvironments = [
         "src",
     ] },
 ]
+
+[dependency-groups]
+dev = [
+    "inline-snapshot>=0.24",
+    "jsonschema>=4",                     # for --resolution=lowest support
+    "mypy>=1.14.1",
+    "nodeenv>=1.9.1",                    # for --resolution=lowest support
+    "packaging>=25",
+    "pre-commit>=3.5",
+    "pytest>=8.3.5",
+    "pytest-cov>=5",
+    "rich-codex>=1.2.11",
+    "ruff>=0.12.4",
+    "typer>=0.15,<0.26",
+    "types-setuptools>=75.8.0.20250110",
+]
+docs = [
+    "markdown-include>=0.8.1",
+    "mike>=2.1.3",
+    "mkdocs>=1.6.1",
+    "mkdocs-github-admonitions-plugin>=0.1.1",
+    "mkdocs-glightbox>=0.4",
+    "mkdocs-include-markdown-plugin>=7.1.7",
+    "mkdocs-material[imaging]~=9.5.18",
+    "mkdocs-material-extensions>=1.3.1",
+    "mkdocs-redirects>=1.2.2",
+    "mkdocs-rss-plugin>=1.15",
+    "mkdocstrings[python]>=0.26.1",
+    "rich-codex>=1.2.11",
+    "typer>=0.15,<0.26",
+]
+
+[tool.uv]
+dependency-groups.docs = { requires-python = ">=3.13" }
 
 [tool.inline-snapshot]
 hash-length = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,15 +47,15 @@ scripts.rich-click = "rich_click.cli:main"
 [dependency-groups]
 dev = [
     "inline-snapshot>=0.24",
-    "jsonschema>=4",                     # for --resolution=lowest support
-    "mypy>=1.14.1",
-    "nodeenv>=1.9.1",                    # for --resolution=lowest support
+    "jsonschema>=4",
+    "mypy>=2.3",
+    "nodeenv>=1.9.1",
     "packaging>=25",
     "prek>=0.4.12",
     "pytest>=8.3.5",
     "pytest-cov>=5",
     "rich-codex>=1.2.11",
-    "ruff>=0.12.4",
+    "ruff>=0.16.2",
     "ty>=0.0.69",
     "typer>=0.15,<0.26",
     "types-setuptools>=75.8.0.20250110",
@@ -80,6 +80,7 @@ docs = [
 dynamic.version = { attr = "rich_click.__version__" }
 
 [tool.uv]
+dependency-groups.dev = { requires-python = ">=3.10" }
 dependency-groups.docs = { requires-python = ">=3.13" }
 
 [tool.ruff]

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -59,7 +59,7 @@ def patch(*args: Any, **kwargs: Any) -> None:  # noqa: D103
     return _patch(*args, **kwargs)
 
 
-class _RichHelpConfigurationParamType(click.ParamType):
+class _RichHelpConfigurationParamType(click.ParamType):  # type: ignore[type-arg]
     name = "JSON"
 
     def __repr__(self) -> str:

--- a/src/rich_click/cli.py
+++ b/src/rich_click/cli.py
@@ -59,7 +59,7 @@ def patch(*args: Any, **kwargs: Any) -> None:  # noqa: D103
     return _patch(*args, **kwargs)
 
 
-class _RichHelpConfigurationParamType(click.ParamType):  # type: ignore[type-arg]
+class _RichHelpConfigurationParamType(click.ParamType):
     name = "JSON"
 
     def __repr__(self) -> str:

--- a/src/rich_click/patch.py
+++ b/src/rich_click/patch.py
@@ -27,7 +27,6 @@ __TyperOption: Type["typer.core.TyperOption"]
 
 
 class _PatchedTyperContext(RichContext):
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         RichContext.__init__(self, *args, **kwargs)
 

--- a/src/rich_click/rich_command.pyi
+++ b/src/rich_click/rich_command.pyi
@@ -41,7 +41,6 @@ G = TypeVar("G", bound=click.Group)
 OVERRIDES_GUARD: bool = False
 
 class RichCommand(click.Command):
-
     context_class: Type[RichContext] = RichContext
     _formatter: Optional[RichHelpFormatter] = None
     panels: List[RichPanel[Any, Any]]

--- a/src/rich_click/rich_context.py
+++ b/src/rich_click/rich_context.py
@@ -10,8 +10,6 @@ from rich_click.rich_help_formatter import RichHelpFormatter
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from types import TracebackType
-
     from rich.console import Console
 
 
@@ -99,19 +97,6 @@ class RichContext(click.Context):
             export_console_as=(self.export_console_as if not error_mode or self.errors_in_output_format else None),
         )
         return formatter
-
-    if TYPE_CHECKING:  # pragma: no cover
-
-        def __enter__(self) -> "RichContext":
-            return super().__enter__()  # type: ignore[return-value]
-
-        def __exit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc_value: Optional[BaseException],
-            tb: Optional[TracebackType],
-        ) -> None:
-            super().__exit__(exc_type, exc_value, tb)
 
 
 def get_current_context(silent: bool = False) -> Optional[RichContext]:

--- a/src/rich_click/rich_help_configuration.py
+++ b/src/rich_click/rich_help_configuration.py
@@ -279,7 +279,6 @@ class RichHelpConfiguration:
     legacy_windows: Optional[bool] = field(default=None)
 
     def __post_init__(self) -> None:  # noqa: D105
-
         if self.highlighter is not None:
             import warnings
 

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -163,7 +163,7 @@ class RichHelpFormatter(click.HelpFormatter):
             import warnings
 
             warnings.warn(
-                "The file kwarg to `RichHelpFormatter()` is deprecated" " and will be removed in a future release.",
+                "The file kwarg to `RichHelpFormatter()` is deprecated and will be removed in a future release.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -327,7 +327,7 @@ class RichHelpFormatter(click.HelpFormatter):
                 res = self.console.export_svg(**kw)
             else:
                 raise ValueError(
-                    "Invalid value for `export_console_as`." " Must be one of 'text', 'html', 'svg', or None."
+                    "Invalid value for `export_console_as`. Must be one of 'text', 'html', 'svg', or None."
                 )
             return res
         else:

--- a/src/rich_click/rich_help_formatter.py
+++ b/src/rich_click/rich_help_formatter.py
@@ -9,10 +9,10 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Iterable,
     Iterator,
     Literal,
     Optional,
-    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -360,7 +360,7 @@ class RichHelpFormatter(click.HelpFormatter):
 
     def write_dl(
         self,
-        rows: Sequence[Tuple[str, str]],
+        rows: Iterable[Tuple[str, str]],
         col_max: int = 30,
         col_spacing: int = 2,
     ) -> None:

--- a/src/rich_click/rich_help_rendering.py
+++ b/src/rich_click/rich_help_rendering.py
@@ -548,7 +548,6 @@ def _get_parameter_help_opt(
 def _get_parameter_default(
     param: Union[click.Argument, click.Option, RichParameter], ctx: RichContext, formatter: RichHelpFormatter
 ) -> Optional[Text]:
-
     if not hasattr(param, "show_default"):
         return None
 
@@ -1088,7 +1087,6 @@ def rich_format_error(
     # attribute. Checking for the 'message' attribute works to make the
     # rich-click CLI compatible.
     if hasattr(self, "message"):
-
         from rich_click.rich_box import get_box
 
         formatter.write(

--- a/src/rich_click/rich_panel.py
+++ b/src/rich_click/rich_panel.py
@@ -134,7 +134,6 @@ class RichPanel(Generic[CT, ColT]):
         raise NotImplementedError()
 
     def _get_base_panel(self, table: "Table", **defaults: Any) -> "Panel":
-
         if self.panel_class is None:
             from rich_click.rich_help_rendering import RichClickRichPanel
 
@@ -181,7 +180,8 @@ class RichOptionPanel(RichPanel[Parameter, OptionColumnType]):
     @classmethod
     def list_all_objects(cls, ctx: Context) -> List[Tuple[str, Parameter]]:
         return [
-            (i.opts[0] if getattr(i, "flag_value", None) and i.opts else i.name, i) for i in ctx.command.get_params(ctx)  # type: ignore[misc]
+            (i.opts[0] if getattr(i, "flag_value", None) and i.opts else i.name, i)  # type: ignore[misc]
+            for i in ctx.command.get_params(ctx)
         ]
 
     def get_objects(self, command: Command, ctx: Context) -> Generator[Parameter, None, None]:
@@ -279,7 +279,6 @@ class RichOptionPanel(RichPanel[Parameter, OptionColumnType]):
                 inline_help_in_title = self.inline_help_in_title
 
             if inline_help_in_title:
-
                 p_styles["title"] = Text("", overflow="ellipsis").join(
                     [
                         Text(title, style=title_style),
@@ -333,7 +332,6 @@ class RichCommandPanel(RichPanel[Command, CommandColumnType]):
         callback_names = {c.callback.__name__: c for c in command.commands.values() if c.callback is not None}
 
         for cmd_name in self.commands:
-
             if cmd_name in commands_list:
                 yield command.get_command(ctx, cmd_name)  # type: ignore[misc]
             elif cmd_name in callback_names:
@@ -381,7 +379,6 @@ class RichCommandPanel(RichPanel[Command, CommandColumnType]):
         rows = []
 
         for cmd in self.get_objects(command, ctx):
-
             from rich_click.rich_command import RichCommand
             from rich_click.rich_help_rendering import get_command_rich_table_row
 
@@ -447,7 +444,6 @@ class RichCommandPanel(RichPanel[Command, CommandColumnType]):
                 inline_help_in_title = self.inline_help_in_title
 
             if inline_help_in_title:
-
                 p_styles["title"] = Text("", overflow="ellipsis").join(
                     [
                         Text(title, style=title_style),
@@ -507,7 +503,6 @@ def _resolve_panels_from_config(
             opts: List[str] = grp.get(panel_cls._object_attr, [])  # type: ignore[assignment]
             traversed = []
             for opt in grp.get(panel_cls._object_attr, []):  # type: ignore[attr-defined]
-
                 if grp.get("deduplicate", True) and opt in [
                     _opt
                     for _grp in final_groups_list

--- a/src/rich_click/rich_panel.py
+++ b/src/rich_click/rich_panel.py
@@ -181,7 +181,7 @@ class RichOptionPanel(RichPanel[Parameter, OptionColumnType]):
     @classmethod
     def list_all_objects(cls, ctx: Context) -> List[Tuple[str, Parameter]]:
         return [
-            (i.opts[0] if getattr(i, "flag_value", None) and i.opts else i.name, i) for i in ctx.command.get_params(ctx)
+            (i.opts[0] if getattr(i, "flag_value", None) and i.opts else i.name, i) for i in ctx.command.get_params(ctx)  # type: ignore[misc]
         ]
 
     def get_objects(self, command: Command, ctx: Context) -> Generator[Parameter, None, None]:

--- a/src/rich_click/rich_panel.py
+++ b/src/rich_click/rich_panel.py
@@ -180,8 +180,7 @@ class RichOptionPanel(RichPanel[Parameter, OptionColumnType]):
     @classmethod
     def list_all_objects(cls, ctx: Context) -> List[Tuple[str, Parameter]]:
         return [
-            (i.opts[0] if getattr(i, "flag_value", None) and i.opts else i.name, i)  # type: ignore[misc]
-            for i in ctx.command.get_params(ctx)
+            (i.opts[0] if getattr(i, "flag_value", None) and i.opts else i.name, i) for i in ctx.command.get_params(ctx)
         ]
 
     def get_objects(self, command: Command, ctx: Context) -> Generator[Parameter, None, None]:
@@ -228,8 +227,8 @@ class RichOptionPanel(RichPanel[Parameter, OptionColumnType]):
         headers = [i.replace("_", " ").title() for i in formatter.config.options_table_column_types]
 
         filtered = [(h, c) for h, c in zip(headers, zip(*rows)) if any(cell for cell in c)]
-        headers, rows = zip(*filtered) if filtered else ([], [])
-        rows = list(map(list, zip(*rows))) if rows else []
+        headers = [h for h, _ in filtered]
+        rows = [list(row) for row in zip(*[c for _, c in filtered])] if filtered else []
 
         for row in rows:
             table.add_row(*row)
@@ -393,8 +392,8 @@ class RichCommandPanel(RichPanel[Command, CommandColumnType]):
         headers = [i.replace("_", " ").title() for i in formatter.config.commands_table_column_types]
 
         filtered = [(h, c) for h, c in zip(headers, zip(*rows)) if any(cell for cell in c)]
-        headers, rows = zip(*filtered) if filtered else ([], [])
-        rows = list(map(list, zip(*rows))) if rows else []
+        headers = [h for h, _ in filtered]
+        rows = [list(row) for row in zip(*[c for _, c in filtered])] if filtered else []
 
         for row in rows:
             table.add_row(*row)

--- a/tests/help/fixtures/options.py
+++ b/tests/help/fixtures/options.py
@@ -1,7 +1,7 @@
 import rich_click as click
 
 
-class Location(click.ParamType):
+class Location(click.ParamType):  # type: ignore[type-arg]
     name = "location"
 
 

--- a/tests/help/fixtures/options.py
+++ b/tests/help/fixtures/options.py
@@ -1,7 +1,7 @@
 import rich_click as click
 
 
-class Location(click.ParamType):  # type: ignore[type-arg]
+class Location(click.ParamType):
     name = "location"
 
 

--- a/tests/help/test_arguments.py
+++ b/tests/help/test_arguments.py
@@ -17,8 +17,7 @@ def cli() -> rich_click.RichCommand:
 def test_arguments_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] INPUT OUTPUT                                                                  \n\
                                                                                                     \n\
@@ -37,8 +36,7 @@ def test_arguments_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> N
 │                                        (current)]                                                │
 │ --help                                 Show this message and exit.                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -46,8 +44,7 @@ def test_arguments_help_with_no_show_arguments(cli_runner: CliRunner, cli: rich_
     rc.SHOW_ARGUMENTS = False
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] INPUT OUTPUT                                                                  \n\
                                                                                                     \n\
@@ -62,8 +59,7 @@ def test_arguments_help_with_no_show_arguments(cli_runner: CliRunner, cli: rich_
 │                                        (current)]                                                │
 │ --help                                 Show this message and exit.                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -71,8 +67,7 @@ def test_arguments_help_with_help_panel_title(cli_runner: CliRunner, cli: rich_c
     rc.ARGUMENTS_PANEL_TITLE = "My amazing tool arguments"
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] INPUT OUTPUT                                                                  \n\
                                                                                                     \n\
@@ -91,8 +86,7 @@ def test_arguments_help_with_help_panel_title(cli_runner: CliRunner, cli: rich_c
 │                                        (current)]                                                │
 │ --help                                 Show this message and exit.                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -101,8 +95,7 @@ def test_arguments_help_with_help_panel_config(cli_runner: CliRunner, cli: rich_
     rc.OPTION_GROUPS = {"cli": [{"name": "My amazing tool arguments", "panel_styles": {"box": box.DOUBLE_EDGE}}]}
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] INPUT OUTPUT                                                                  \n\
                                                                                                     \n\
@@ -121,8 +114,7 @@ def test_arguments_help_with_help_panel_config(cli_runner: CliRunner, cli: rich_
 │                                        (current)]                                                │
 │ --help                                 Show this message and exit.                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -130,8 +122,7 @@ def test_arguments_help_grouped_with_options(cli_runner: CliRunner, cli: rich_cl
     rc.GROUP_ARGUMENTS_OPTIONS = True
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] INPUT OUTPUT                                                                  \n\
                                                                                                     \n\
@@ -148,6 +139,5 @@ def test_arguments_help_grouped_with_options(cli_runner: CliRunner, cli: rich_cl
 │                                           (current)]                                             │
 │    --help                                 Show this message and exit.                            │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_class_overrides.py
+++ b/tests/help/test_class_overrides.py
@@ -16,8 +16,7 @@ def cli() -> rich_click.RichCommand:
 def test_class_overrides_command_panel(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -36,8 +35,7 @@ def test_class_overrides_command_panel(cli_runner: CliRunner, cli: rich_click.Ri
 │ cmd1   Test that command is assigned to Rich Click Panel 2 via the decorator argument.           │
 │ grp1   Test that group is assigned to Rich Click Panel 2 via the decorator argument.             │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -52,8 +50,7 @@ def test_class_overrides_click_command(cli_runner: CliRunner, cli: rich_click.Ri
 
     result = cli_runner.invoke(cmd, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Usage: click-command [OPTIONS] RICH_CLICK_ARG
 
   Test that RichParameters can be used with base click Commands.
@@ -61,8 +58,7 @@ Usage: click-command [OPTIONS] RICH_CLICK_ARG
 Options:
   --rich-click-option TEXT
   --help                    Show this message and exit.
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -75,8 +71,7 @@ def test_class_overrides_click_parameters(cli_runner: CliRunner, cli: rich_click
 
     result = cli_runner.invoke(cmd, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: click-options [OPTIONS] CLICK_ARG                                                           \n\
                                                                                                     \n\
@@ -90,6 +85,5 @@ def test_class_overrides_click_parameters(cli_runner: CliRunner, cli: rich_click
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_context_settings.py
+++ b/tests/help/test_context_settings.py
@@ -17,8 +17,7 @@ def cli() -> rich_click.RichCommand:
 def test_context_settings_help_for_click_8_1_plus(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -34,8 +33,7 @@ def test_context_settings_help_for_click_8_1_plus(cli_runner: CliRunner, cli: ri
 │ --version        Show the version and exit.                                                      │
 │ --help           Show this message and exit.                                                     │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -43,8 +41,7 @@ def test_context_settings_help_for_click_8_1_plus(cli_runner: CliRunner, cli: ri
 def test_context_settings_help_for_click_8_0(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -60,6 +57,5 @@ def test_context_settings_help_for_click_8_0(cli_runner: CliRunner, cli: rich_cl
 │ --version        Show the version and exit. [default: False]                                     │
 │ --help           Show this message and exit. [default: False]                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_custom_errors.py
+++ b/tests/help/test_custom_errors.py
@@ -18,8 +18,7 @@ def test_custom_errors_bad_input(cli_runner: CliRunner, cli: rich_click.RichComm
     result = cli_runner.invoke(cli, "bad_input")
     assert result.exit_code == 2
     assert result.stdout == snapshot("")
-    assert result.stderr == snapshot(
-        """\
+    assert result.stderr == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] INPUT                                                                         \n\
                                                                                                     \n\
@@ -30,5 +29,4 @@ def test_custom_errors_bad_input(cli_runner: CliRunner, cli: rich_click.RichComm
                                                                                                     \n\
  To find out more, visit https://mytool.com                                                         \n\
                                                                                                     \n\
-"""
-    )
+""")

--- a/tests/help/test_declarative.py
+++ b/tests/help/test_declarative.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_declarative_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -29,16 +28,14 @@ def test_declarative_help(cli_runner: CliRunner, cli: rich_click.RichCommand) ->
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
 │ check                Check the context type.                                                     │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_declarative_subcommand_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "check --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli check [OPTIONS]                                                                         \n\
@@ -48,18 +45,15 @@ Debug mode is off
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_context_type(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "check")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
 Ctx is RichContext
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_defaults.py
+++ b/tests/help/test_defaults.py
@@ -16,8 +16,7 @@ def cli() -> rich_click.RichCommand:
 def test_defaults_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -33,16 +32,14 @@ def test_defaults_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> No
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
 │ download                             Download files                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_defaults_help_subcommand_with_show_default_string(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "download --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Environment: None
 Debug mode is off
                                                                                                     \n\
@@ -54,8 +51,7 @@ Debug mode is off
 │ --files  TEXT  What files to download [default: (All files)]                                     │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -65,8 +61,7 @@ def test_defaults_help_subcommand_with_show_default_string_and_markdown(
     rc.TEXT_MARKUP = "markdown"
     result = cli_runner.invoke(cli, "download --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Environment: None
 Debug mode is off
                                                                                                     \n\
@@ -79,6 +74,5 @@ Debug mode is off
 │                [default: (All files)]                                                            │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_deprecated.py
+++ b/tests/help/test_deprecated.py
@@ -18,8 +18,7 @@ def cli() -> rich_click.RichCommand:
 def test_deprecated_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -40,8 +39,7 @@ def test_deprecated_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> 
 │ sync      Synchronise all your files between two places. Example command that doesn't do much    │
 │           except print to the terminal. [deprecated: Removing in later version]                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -49,8 +47,7 @@ def test_deprecated_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> 
 def test_deprecated_help_subcommand_bool(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "download --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli download [OPTIONS]                                                                      \n\
                                                                                                     \n\
@@ -61,8 +58,7 @@ def test_deprecated_help_subcommand_bool(cli_runner: CliRunner, cli: rich_click.
 │ --all   Get everything                                                                           │
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -70,8 +66,7 @@ def test_deprecated_help_subcommand_bool(cli_runner: CliRunner, cli: rich_click.
 def test_deprecated_help_subcommand_string(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "sync --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli sync [OPTIONS]                                                                          \n\
                                                                                                     \n\
@@ -83,8 +78,7 @@ def test_deprecated_help_subcommand_string(cli_runner: CliRunner, cli: rich_clic
 │ --all                                                                                            │
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -93,8 +87,7 @@ def test_deprecated_help_with_markdown(cli_runner: CliRunner, cli: rich_click.Ri
     rc.TEXT_MARKUP = "markdown"
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -121,8 +114,7 @@ def test_deprecated_help_with_markdown(cli_runner: CliRunner, cli: rich_click.Ri
 │           except print to the terminal.                                                          │
 │           [deprecated: Removing in later version]                                                │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -131,8 +123,7 @@ def test_deprecated_help_subcommand_bool_with_markdown(cli_runner: CliRunner, cl
     rc.TEXT_MARKUP = "markdown"
     result = cli_runner.invoke(cli, "download --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli download [OPTIONS]                                                                      \n\
                                                                                                     \n\
@@ -143,8 +134,7 @@ def test_deprecated_help_subcommand_bool_with_markdown(cli_runner: CliRunner, cl
 │ --all   Get everything                                                                           │
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -153,8 +143,7 @@ def test_deprecated_help_subcommand_string_with_markdown(cli_runner: CliRunner, 
     rc.TEXT_MARKUP = "markdown"
     result = cli_runner.invoke(cli, "sync --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli sync [OPTIONS]                                                                          \n\
                                                                                                     \n\
@@ -166,6 +155,5 @@ def test_deprecated_help_subcommand_string_with_markdown(cli_runner: CliRunner, 
 │ --all                                                                                            │
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_envvar.py
+++ b/tests/help/test_envvar.py
@@ -16,8 +16,7 @@ def cli() -> rich_click.RichCommand:
 def test_envvar_greet_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "greet --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli greet [OPTIONS]                                                                         \n\
@@ -31,8 +30,7 @@ Debug mode is off
 │ --token     -t  TEXT  [env var: GREETER_GREET_TOKEN]                                             │
 │ --help                Show this message and exit.                                                │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -40,8 +38,7 @@ def test_envvar_greet_help_with_envvar_string(cli_runner: CliRunner, cli: rich_c
     rc.ENVVAR_STRING = "(ENV: {})"
     result = cli_runner.invoke(cli, "greet --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli greet [OPTIONS]                                                                         \n\
@@ -55,6 +52,5 @@ Debug mode is off
 │ --token     -t  TEXT  (ENV: GREETER_GREET_TOKEN)                                                 │
 │ --help                Show this message and exit.                                                │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_epilog_and_footer.py
+++ b/tests/help/test_epilog_and_footer.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_epilog_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -38,16 +37,14 @@ def test_epilog_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None
                                                                                                     \n\
  And here is some footer text!                                                                      \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_epilog_help_subcommand_no_footer(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "no-footer --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli no-footer [OPTIONS]                                                                     \n\
@@ -60,16 +57,14 @@ Debug mode is off
                                                                                                     \n\
  This is epilog text                                                                                \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_epilog_help_subcommand_no_epilog(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "no-epilog --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli no-epilog [OPTIONS]                                                                     \n\
@@ -82,16 +77,14 @@ Debug mode is off
                                                                                                     \n\
  This is footer text                                                                                \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_epilog_help_subcommand_footer_is_rich_text(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "footer-is-rich-text --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli footer-is-rich-text [OPTIONS]                                                           \n\
@@ -107,16 +100,14 @@ Debug mode is off
                                                                                                     \n\
  Rich text footer                                                                                   \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_epilog_help_subcommand_epilog_is_rich_text(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "epilog-is-rich-text --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli epilog-is-rich-text [OPTIONS]                                                           \n\
@@ -129,8 +120,7 @@ Debug mode is off
                                                                                                     \n\
  Rich text epilog                                                                                   \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -138,8 +128,7 @@ def test_epilog_help_turn_off_rich_markup(cli_runner: CliRunner, cli: rich_click
     cli.context_settings["rich_help_config"]["text_markup"] = None
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -161,6 +150,5 @@ def test_epilog_help_turn_off_rich_markup(cli_runner: CliRunner, cli: rich_click
                                                                                                     \n\
  And here is some footer text!                                                                      \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_flag_values.py
+++ b/tests/help/test_flag_values.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_flag_values_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -28,6 +27,5 @@ def test_flag_values_help(cli_runner: CliRunner, cli: rich_click.RichCommand) ->
 │ --c     C flag.                                                                                  │
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_groups_sorting.py
+++ b/tests/help/test_groups_sorting.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_groups_sorting_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -42,16 +41,14 @@ def test_groups_sorting_help(cli_runner: CliRunner, cli: rich_click.RichCommand)
 │ config                Set up the configuration.                                                  │
 │ auth                  Authenticate the app.                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_groups_sorting_help_subcommand_sync(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "sync --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli sync [OPTIONS]                                                                          \n\
@@ -69,16 +66,14 @@ Debug mode is off
 │ --all        Sync all the things?                                                                │
 │ --overwrite  Overwrite local files                                                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_groups_sorting_help_subcommand_download(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "download --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli download [OPTIONS]                                                                      \n\
@@ -91,16 +86,14 @@ Debug mode is off
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --all  Get everything                                                                            │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_groups_sorting_help_subcommand_config(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "config --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli config [OPTIONS]                                                                        \n\
@@ -110,16 +103,14 @@ Debug mode is off
 ╭─ Subcommand help ────────────────────────────────────────────────────────────────────────────────╮
 │ --help  -h  Show this message and exit.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_groups_sorting_help_subcommand_auth(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "auth --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli auth [OPTIONS]                                                                          \n\
@@ -137,6 +128,5 @@ Debug mode is off
 ╭─ Auth help ──────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  -h  Show this message and exit.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_header.py
+++ b/tests/help/test_header.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_header_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Welcome to my CLI!                                                                                 \n\
                                                                                                     \n\
@@ -31,16 +30,14 @@ def test_header_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
 │ subcommand                        Subcommand help text                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_header_subcommand_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "subcommand --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Welcome to my CLI! (with Text())                                                                   \n\
@@ -52,8 +49,7 @@ Debug mode is off
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -61,8 +57,7 @@ def test_header_help_turn_off_rich_markup(cli_runner: CliRunner, cli: rich_click
     cli.context_settings["rich_help_config"]["text_markup"] = None
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  [magenta]Welcome to my CLI![/]                                                                     \n\
                                                                                                     \n\
@@ -77,6 +72,5 @@ def test_header_help_turn_off_rich_markup(cli_runner: CliRunner, cli: rich_click
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
 │ subcommand                        Subcommand help text                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_markdown.py
+++ b/tests/help/test_markdown.py
@@ -24,8 +24,7 @@ def test_markdown_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> No
     with pytest.warns(PendingDeprecationWarning, match=r"`use_markdown=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -50,8 +49,7 @@ def test_markdown_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> No
 │                ╚═══════════════════════════════════════════════════════════════════════════════╝ │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -60,8 +58,7 @@ def test_markdown_help_turn_off_markdown(cli_runner: CliRunner, cli: rich_click.
     with pytest.warns(PendingDeprecationWarning, match=r"`use_markdown=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -79,8 +76,7 @@ def test_markdown_help_turn_off_markdown(cli_runner: CliRunner, cli: rich_click.
 │ --debug        # Enable `debug mode`                                                             │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -98,8 +94,7 @@ def test_markdown_help_text_markup_field(cli_runner: CliRunner, cli: rich_click.
     with pytest.warns(PendingDeprecationWarning, match=r"`use_markdown=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -124,8 +119,7 @@ def test_markdown_help_text_markup_field(cli_runner: CliRunner, cli: rich_click.
 │                ╚═══════════════════════════════════════════════════════════════════════════════╝ │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -135,8 +129,7 @@ def test_markdown_help_rich_13(cli_runner: CliRunner, cli: rich_click.RichComman
     with pytest.warns(PendingDeprecationWarning, match=r"`use_markdown=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -161,8 +154,7 @@ def test_markdown_help_rich_13(cli_runner: CliRunner, cli: rich_click.RichComman
 │                ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -181,8 +173,7 @@ def test_markdown_help_text_markup_field_rich_13(cli_runner: CliRunner, cli: ric
     with pytest.warns(PendingDeprecationWarning, match=r"`use_markdown=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -207,6 +198,5 @@ def test_markdown_help_text_markup_field_rich_13(cli_runner: CliRunner, cli: ric
 │                ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_metavars.py
+++ b/tests/help/test_metavars.py
@@ -16,8 +16,7 @@ def cli() -> rich_click.RichCommand:
 def test_metavars_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -35,8 +34,7 @@ def test_metavars_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> No
 │           seven|twenty-eight|twenty-nine|thirty]                                                 │
 │ --help                                                Show this message and exit.                │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -48,8 +46,7 @@ def test_metavars_help_flipped(cli_runner: CliRunner, cli: rich_click.RichComman
 
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -65,8 +62,7 @@ def test_metavars_help_flipped(cli_runner: CliRunner, cli: rich_click.RichComman
 │           ty-four|twenty-five|twenty-six|twenty-seven|twenty-eight|twenty-nine|thirty)           │
 │ --help    Show this message and exit.                                                            │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -80,8 +76,7 @@ def test_metavars_help_flipped_help_string(cli_runner: CliRunner, cli: rich_clic
 
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -97,6 +92,5 @@ def test_metavars_help_flipped_help_string(cli_runner: CliRunner, cli: rich_clic
 │           y-four|twenty-five|twenty-six|twenty-seven|twenty-eight|twenty-nine|thirty]            │
 │ --help    Show this message and exit.                                                            │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_options.py
+++ b/tests/help/test_options.py
@@ -22,8 +22,7 @@ def cli() -> rich_click.RichCommand:
 def test_options_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -41,8 +40,7 @@ def test_options_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> Non
 │    --help            -h                           Show help.                                     │
 │    --version         -v                           Show version.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -51,8 +49,7 @@ def test_options_help_envvar_first(cli_runner: CliRunner, cli: rich_click.RichCo
     with pytest.warns(PendingDeprecationWarning, match=r"`option_envvar_first=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -70,8 +67,7 @@ def test_options_help_envvar_first(cli_runner: CliRunner, cli: rich_click.RichCo
 │    --help            -h                           Show help.                                     │
 │    --version         -v                           Show version.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -80,8 +76,7 @@ def test_options_help_dont_show_metavars(cli_runner: CliRunner, cli: rich_click.
     with pytest.warns(PendingDeprecationWarning, match=r"`show_metavars_column=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -98,6 +93,5 @@ def test_options_help_dont_show_metavars(cli_runner: CliRunner, cli: rich_click.
 │    --help            -h  Show help.                                                              │
 │    --version         -v  Show version.                                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_panels_defaults.py
+++ b/tests/help/test_panels_defaults.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_panels_defaults_command_panel(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -43,16 +42,14 @@ def test_panels_defaults_command_panel(cli_runner: CliRunner, cli: rich_click.Ri
   cmd2                             cmd2 help                                                        \n\
   cmd3                             cmd3 help                                                        \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panels_defaults_argument_panel(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd4 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd4 [OPTIONS] ARG1 ARG3 ARG2                                                           \n\
                                                                                                     \n\
@@ -67,16 +64,14 @@ def test_panels_defaults_argument_panel(cli_runner: CliRunner, cli: rich_click.R
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panels_defaults_order(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd6 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd6 [OPTIONS]                                                                          \n\
                                                                                                     \n\
@@ -98,6 +93,5 @@ def test_panels_defaults_order(cli_runner: CliRunner, cli: rich_click.RichComman
 ╭─ Panel 3 ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --d  TEXT                                                                                        │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_panels_sorting.py
+++ b/tests/help/test_panels_sorting.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_command_panel_order(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -48,16 +47,14 @@ def test_command_panel_order(cli_runner: CliRunner, cli: rich_click.RichCommand)
 │ cmd12  Test all three methods of assigning a panel don't cause duplication.                      │
 │ cmd13  Test that command_panel.commands takes priority.                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panel_order_in_panel_decorator(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd1 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd1 [OPTIONS]                                                                          \n\
                                                                                                     \n\
@@ -78,16 +75,14 @@ def test_panel_order_in_panel_decorator(cli_runner: CliRunner, cli: rich_click.R
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_option_order_with_panel_decorator(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd2 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd2 [OPTIONS]                                                                          \n\
                                                                                                     \n\
@@ -108,16 +103,14 @@ def test_option_order_with_panel_decorator(cli_runner: CliRunner, cli: rich_clic
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panel_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd3 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd3 [OPTIONS]                                                                          \n\
                                                                                                     \n\
@@ -138,16 +131,14 @@ def test_panel_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.Ric
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_option_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd4 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd4 [OPTIONS]                                                                          \n\
                                                                                                     \n\
@@ -168,16 +159,14 @@ def test_option_order_with_panel_kwarg(cli_runner: CliRunner, cli: rich_click.Ri
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panel_order_commands_above_options(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd5 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd5 [OPTIONS] COMMAND [ARGS]...                                                        \n\
                                                                                                     \n\
@@ -190,16 +179,14 @@ def test_panel_order_commands_above_options(cli_runner: CliRunner, cli: rich_cli
 │ --a     TEXT                                                                                     │
 │ --help        Show this message and exit.                                                        │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panel_order_options_above_commands(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd6 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd6 [OPTIONS] COMMAND [ARGS]...                                                        \n\
                                                                                                     \n\
@@ -213,16 +200,14 @@ def test_panel_order_options_above_commands(cli_runner: CliRunner, cli: rich_cli
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
 │ dummy                                                                                            │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panel_order_options_above_commands_with_arguments(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd7 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd7 [OPTIONS] A COMMAND [ARGS]...                                                      \n\
                                                                                                     \n\
@@ -238,16 +223,14 @@ def test_panel_order_options_above_commands_with_arguments(cli_runner: CliRunner
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
 │ dummy                                                                                            │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panel_order_arguments_options_commands(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd8 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd8 [OPTIONS] A COMMAND [ARGS]...                                                      \n\
                                                                                                     \n\
@@ -263,16 +246,14 @@ def test_panel_order_arguments_options_commands(cli_runner: CliRunner, cli: rich
 │ --b     TEXT                                                                                     │
 │ --help        Show this message and exit.                                                        │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panel_option_and_command_same_name(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd9 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd9 [OPTIONS] COMMAND [ARGS]...                                                        \n\
                                                                                                     \n\
@@ -289,16 +270,14 @@ def test_panel_option_and_command_same_name(cli_runner: CliRunner, cli: rich_cli
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
 │ samename                                                                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_panel_different_type_panels_same_name(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd10 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd10 [OPTIONS] COMMAND [ARGS]...                                                       \n\
                                                                                                     \n\
@@ -314,16 +293,14 @@ def test_panel_different_type_panels_same_name(cli_runner: CliRunner, cli: rich_
 │ --foo  TEXT                                                                                      │
 │ --bar  TEXT                                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_add_command_panel_kwarg(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd11 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd11 [OPTIONS] COMMAND [ARGS]...                                                       \n\
                                                                                                     \n\
@@ -335,16 +312,14 @@ def test_add_command_panel_kwarg(cli_runner: CliRunner, cli: rich_click.RichComm
 ╭─ Some Panel ─────────────────────────────────────────────────────────────────────────────────────╮
 │ dummy2                                                                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_no_duplicatio_of_commands(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd12 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd12 [OPTIONS] COMMAND [ARGS]...                                                       \n\
                                                                                                     \n\
@@ -356,16 +331,14 @@ def test_no_duplicatio_of_commands(cli_runner: CliRunner, cli: rich_click.RichCo
 ╭─ Some Panel ─────────────────────────────────────────────────────────────────────────────────────╮
 │ dummy2                                                                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_ignore_behavior_duplicate_assignments(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "cmd13 --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli cmd13 [OPTIONS] COMMAND [ARGS]...                                                       \n\
                                                                                                     \n\
@@ -377,6 +350,5 @@ def test_ignore_behavior_duplicate_assignments(cli_runner: CliRunner, cli: rich_
 ╭─ Prioritize me ──────────────────────────────────────────────────────────────────────────────────╮
 │ dummy2                                                                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_panels_styles.py
+++ b/tests/help/test_panels_styles.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_styles_command_panel(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -30,16 +29,14 @@ def test_styles_command_panel(cli_runner: CliRunner, cli: rich_click.RichCommand
   subcommand              Test basic styles for option panel.                                       \n\
                                         Additional Commands                                         \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_styles_options_panel(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "subcommand --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli subcommand [OPTIONS]                                                                    \n\
                                                                                                     \n\
@@ -55,6 +52,5 @@ def test_styles_options_panel(cli_runner: CliRunner, cli: rich_click.RichCommand
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_rich_markup.py
+++ b/tests/help/test_rich_markup.py
@@ -17,8 +17,7 @@ def test_rich_markup_help(cli_runner: CliRunner, cli: rich_click.RichCommand) ->
     with pytest.warns(PendingDeprecationWarning, match=r"`use_rich_markup=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -33,8 +32,7 @@ def test_rich_markup_help(cli_runner: CliRunner, cli: rich_click.RichCommand) ->
 │ --debug        Enable 👉 debug mode 👈                                                           │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -43,8 +41,7 @@ def test_rich_markup_help_turn_off_rich_markup(cli_runner: CliRunner, cli: rich_
     with pytest.warns(PendingDeprecationWarning, match=r"`use_rich_markup=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -60,8 +57,7 @@ def test_rich_markup_help_turn_off_rich_markup(cli_runner: CliRunner, cli: rich_
 │ --debug        Enable :point_right: [yellow]debug mode[/] :point_left:                           │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -78,8 +74,7 @@ def test_markdown_help_text_markup_field(cli_runner: CliRunner, cli: rich_click.
     with pytest.warns(PendingDeprecationWarning, match=r"`use_rich_markup=` will be deprecated.*"):
         result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -94,6 +89,5 @@ def test_markdown_help_text_markup_field(cli_runner: CliRunner, cli: rich_click.
 │ --debug        Enable 👉 debug mode 👈                                                           │
 │ --help         Show this message and exit.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_simple.py
+++ b/tests/help/test_simple.py
@@ -17,8 +17,7 @@ def cli() -> rich_click.RichCommand:
 def test_simple_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -41,8 +40,7 @@ def test_simple_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None
 │ sync      Synchronise all your files between two places. Example command that doesn't do much    │
 │           except print to the terminal.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -56,8 +54,7 @@ def test_simple_help_no_args_is_help(cli_runner: CliRunner, cli: rich_click.Rich
         assert result.exit_code == 0
     else:
         assert result.exit_code == 2
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -80,8 +77,7 @@ def test_simple_help_no_args_is_help(cli_runner: CliRunner, cli: rich_click.Rich
 │ sync      Synchronise all your files between two places. Example command that doesn't do much    │
 │           except print to the terminal.                                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
     result_with_help = cli_runner.invoke(cli, "--help")
@@ -93,8 +89,7 @@ def test_simple_help_commands_before_options(cli_runner: CliRunner, cli: rich_cl
     rc.COMMANDS_BEFORE_OPTIONS = True
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -117,8 +112,7 @@ def test_simple_help_commands_before_options(cli_runner: CliRunner, cli: rich_cl
 │                            Double newlines are preserved.                                        │
 │ --help                     Show this message and exit.                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -127,8 +121,7 @@ def test_simple_help_no_such_command(cli_runner: CliRunner, cli: rich_click.Rich
     result = cli_runner.invoke(cli, "bad-input")
     assert result.exit_code == 2
     assert result.stdout == snapshot("")
-    assert result.stderr == snapshot(
-        """\
+    assert result.stderr == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -137,16 +130,14 @@ def test_simple_help_no_such_command(cli_runner: CliRunner, cli: rich_click.Rich
 │ No such command 'bad-input'.                                                                     │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                     \n\
-"""
-    )
+""")
 
 
 def test_simple_help_nu_theme(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     rc.THEME = "nu"
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
  My amazing tool does all the things.                                                               \n\
@@ -168,8 +159,7 @@ def test_simple_help_nu_theme(cli_runner: CliRunner, cli: rich_click.RichCommand
  sync      Synchronise all your files between two places. Example command that doesn't do much      \n\
            except print to the terminal.                                                            \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -177,8 +167,7 @@ def test_simple_help_slim_theme(cli_runner: CliRunner, cli: rich_click.RichComma
     rc.THEME = "slim"
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Usage: cli [OPTIONS] COMMAND [ARGS]...                                                              \n\
                                                                                                     \n\
 My amazing tool does all the things.                                                                \n\
@@ -200,8 +189,7 @@ Commands:                                                                       
   sync      Synchronise all your files between two places. Example command that doesn't do much     \n\
             except print to the terminal.                                                           \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -209,8 +197,7 @@ def test_simple_help_modern_theme(cli_runner: CliRunner, cli: rich_click.RichCom
     rc.THEME = "modern"
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
   Usage: cli [OPTIONS] COMMAND [ARGS]...                                                            \n\
                                                                                                     \n\
@@ -237,8 +224,7 @@ def test_simple_help_modern_theme(cli_runner: CliRunner, cli: rich_click.RichCom
              except print to the terminal.                                                          \n\
                                                                                                     \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -246,8 +232,7 @@ def test_simple_help_robo_theme(cli_runner: CliRunner, cli: rich_click.RichComma
     rc.THEME = "robo"
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Usage: cli [OPTIONS] COMMAND [ARGS]...                                                              \n\
                                                                                                     \n\
 My amazing tool does all the things.                                                                \n\
@@ -273,6 +258,5 @@ Here are things you can do:                                                     
 │            except print to the terminal.                                                         │
 │                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_table_styles.py
+++ b/tests/help/test_table_styles.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_table_styles_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -98,6 +97,5 @@ def test_table_styles_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -
 │ ║          ║ convallis.                                                                        ║ │
 │ ╚══════════╩═══════════════════════════════════════════════════════════════════════════════════╝ │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/help/test_wildcard_groups.py
+++ b/tests/help/test_wildcard_groups.py
@@ -15,8 +15,7 @@ def cli() -> rich_click.RichCommand:
 def test_wildcard_groups_help(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS] COMMAND [ARGS]...                                                             \n\
                                                                                                     \n\
@@ -40,16 +39,14 @@ def test_wildcard_groups_help(cli_runner: CliRunner, cli: rich_click.RichCommand
 │ config                Set up the configuration.                                                  │
 │ auth                  Authenticate the app.                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
 def test_wildcard_groups_help_subcommand_sync(cli_runner: CliRunner, cli: rich_click.RichCommand) -> None:
     result = cli_runner.invoke(cli, "sync --help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
 Debug mode is off
                                                                                                     \n\
  Usage: cli sync [OPTIONS]                                                                          \n\
@@ -65,6 +62,5 @@ Debug mode is off
 │ *  --input   -i  TEXT  Input path [required]                                                     │
 │    --output  -o  TEXT  Output path                                                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,8 +186,7 @@ def test_custom_console(cli_runner: CliRunner) -> None:
 
     cli_runner.invoke(cli, "--help")
 
-    assert f.getvalue() == snapshot(
-        """\
+    assert f.getvalue() == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -196,5 +195,4 @@ def test_custom_console(cli_runner: CliRunner) -> None:
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -39,7 +39,6 @@ def test_deprecation_warning_on_highlighter(cli_runner: CliRunner) -> None:
 
 
 def test_deprecation_cli_patch() -> None:
-
     with patch("rich_click.cli._patch") as mock_underlying_patch:
         with pytest.warns(DeprecationWarning, match=r"`rich_click\.cli\.patch\(\)` has moved.*"):
             import rich_click.cli
@@ -50,7 +49,6 @@ def test_deprecation_cli_patch() -> None:
 
 
 def test_deprecation_command_help_config() -> None:
-
     @rich_click.command()
     def cli1() -> None:
         pass
@@ -70,7 +68,6 @@ def test_deprecation_command_help_config() -> None:
 
 
 def test_deprecation_command_console() -> None:
-
     @rich_click.command()
     def cli1() -> None:
         pass
@@ -90,7 +87,6 @@ def test_deprecation_command_console() -> None:
 
 
 def test_not_implemented_warnings_for_help_formatter() -> None:
-
     formatter = rich_click.RichHelpFormatter()
 
     with pytest.warns(RuntimeWarning):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -21,11 +21,9 @@ def test_abort(cli_runner: CliRunner) -> None:
     res = cli_runner.invoke(cli)
 
     assert res.stdout == snapshot("")
-    assert res.stderr == snapshot(
-        """\
+    assert res.stderr == snapshot("""\
 \x1b[31mAborted.\x1b[0m
-"""
-    )
+""")
 
 
 def test_child_context_inherits_errors_in_output_format() -> None:
@@ -61,8 +59,7 @@ def test_help_to_stderr(cli_runner: CliRunner) -> None:
 
     assert res.exit_code == 0
     assert res.stdout == snapshot("")
-    assert res.stderr == snapshot(
-        """\
+    assert res.stderr == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
@@ -71,5 +68,4 @@ def test_help_to_stderr(cli_runner: CliRunner) -> None:
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")

--- a/tests/test_no_rich_imports.py
+++ b/tests/test_no_rich_imports.py
@@ -82,16 +82,14 @@ def test_imports_during_help(recorded_imports: List[str], cli_runner: CliRunner)
 
     res = cli_runner.invoke(cli, "--help")
     assert res.exit_code == 0
-    assert res.stdout == snapshot(
-        """\
+    assert res.stdout == snapshot("""\
                                                                                                     \n\
  Usage: cli [OPTIONS]                                                                               \n\
                                                                                                     \n\
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
     assert any(m.startswith("click.") or m == "click" for m in recorded_imports)
     assert any(m.startswith("rich.") or m == "rich" for m in recorded_imports)
@@ -125,16 +123,14 @@ def test_imports_during_help_rich_click_cli(
 
     res = cli_runner.invoke(main, f"{check_imports_cli / 'my_script.py'} --help")
     assert res.exit_code == 0
-    assert res.stdout == snapshot(
-        """\
+    assert res.stdout == snapshot("""\
                                                                                                     \n\
  Usage: mymodule [OPTIONS]                                                                          \n\
                                                                                                     \n\
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
     assert any(m.startswith("click.") or m == "click" for m in recorded_imports)
     assert any(m.startswith("rich.") or m == "rich" for m in recorded_imports)

--- a/tests/test_rich_click_cli.py
+++ b/tests/test_rich_click_cli.py
@@ -16,8 +16,7 @@ from tests.conftest import WriteScript, run_as_subprocess
 
 @pytest.fixture
 def simple_script(mock_script_writer: WriteScript) -> Path:
-    return mock_script_writer(
-        '''
+    return mock_script_writer('''
         import click
 
         # Test if robust to subclassing
@@ -28,8 +27,7 @@ def simple_script(mock_script_writer: WriteScript) -> Path:
         def cli():
             """My help text"""
             print('Hello, world!')
-        '''
-    )
+        ''')
 
 
 @pytest.mark.parametrize(
@@ -42,8 +40,7 @@ def simple_script(mock_script_writer: WriteScript) -> Path:
 def test_simple_rich_click_cli(simple_script: Path, command: List[str]) -> None:
     res = run_as_subprocess([sys.executable, "-m", "src.rich_click", "mymodule:cli", "--help"])
     assert res.returncode == 0
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS]                                                 \n\
                                                                                                     \n\
@@ -52,8 +49,7 @@ def test_simple_rich_click_cli(simple_script: Path, command: List[str]) -> None:
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
 
 @pytest.mark.parametrize(
@@ -95,8 +91,7 @@ def test_rich_click_cli_help_with_rich_config_from_file(tmp_path: Path) -> None:
 
     res = run_as_subprocess([sys.executable, "-m", "src.rich_click", "--rich-config", f"@{config_file}", "--help"])
     assert res.returncode == 0
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click [OPTIONS] SCRIPT | MODULE[:CLICK_COMMAND] ...                      \n\
                                                                                                     \n\
@@ -139,8 +134,7 @@ def test_rich_click_cli_help_with_rich_config_from_file(tmp_path: Path) -> None:
 │ --output       -o  [html|svg|text]  Optionally render help text as HTML or SVG or plain text. By │
 │                                     default, help text is rendered normally.                     │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
 
 def test_rich_click_cli_help_with_bad_rich_config() -> None:
@@ -170,8 +164,7 @@ def test_custom_config_rich_click_cli(simple_script: Path) -> None:
         ]
     )
     assert res.returncode == 0
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS]                                                 \n\
                                                                                                     \n\
@@ -180,8 +173,7 @@ def test_custom_config_rich_click_cli(simple_script: Path) -> None:
 ╭─ Custom Name ────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
 
 def test_override_click_command(mock_script_writer: Callable[[str], Path]) -> None:
@@ -211,8 +203,7 @@ def test_override_click_command(mock_script_writer: Callable[[str], Path]) -> No
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS]                                                 \n\
                                                                                                     \n\
@@ -221,8 +212,7 @@ def test_override_click_command(mock_script_writer: Callable[[str], Path]) -> No
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
 
 def test_override_click_group(mock_script_writer: Callable[[str], Path]) -> None:
@@ -260,8 +250,7 @@ def test_override_click_group(mock_script_writer: Callable[[str], Path]) -> None
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
                                                                                                     \n\
@@ -273,13 +262,11 @@ def test_override_click_group(mock_script_writer: Callable[[str], Path]) -> None
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
 │ subcommand                        Subcommand help text                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
 
 def test_override_rich_click_command(mock_script_writer: WriteScript) -> None:
-    mock_script_writer(
-        '''
+    mock_script_writer('''
         import rich_click as click
 
         # Test if robust to subclassing
@@ -297,21 +284,18 @@ def test_override_rich_click_command(mock_script_writer: WriteScript) -> None:
         def cli():
             """My help text"""
             print('Hello, world!')
-        '''
-    )
+        ''')
 
     res = run_as_subprocess([sys.executable, "-m", "rich_click", "mymodule:cli", "--help"])
     assert res.returncode == 0
 
     assert res.returncode == 0
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
 I am overriding RichCommand! (usage)
 I am overriding RichCommand! (help_text)
 I am overriding RichCommand! (options)
 I am overriding RichCommand! (epilog)
-"""
-    )
+""")
 
 
 def test_override_rich_click_group(mock_script_writer: Callable[[str], Path]) -> None:
@@ -346,14 +330,12 @@ def test_override_rich_click_group(mock_script_writer: Callable[[str], Path]) ->
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
 I am overriding RichCommand! (usage)
 I am overriding RichCommand! (help_text)
 I am overriding RichCommand! (options)
 I am overriding RichCommand! (epilog)
-"""
-    )
+""")
 
 
 def test_override_rich_click_command_collection(mock_script_writer: Callable[[str], Path]) -> None:
@@ -392,14 +374,12 @@ def test_override_rich_click_command_collection(mock_script_writer: Callable[[st
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
 I am overriding RichCommand! (usage)
 I am overriding RichCommand! (help_text)
 I am overriding RichCommand! (options)
 I am overriding RichCommand! (epilog)
-"""
-    )
+""")
 
 
 def test_override_guard_click_command(mock_script_writer: Callable[[str], Path]) -> None:
@@ -429,8 +409,7 @@ def test_override_guard_click_command(mock_script_writer: Callable[[str], Path])
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS]                                                 \n\
                                                                                                     \n\
@@ -439,8 +418,7 @@ def test_override_guard_click_command(mock_script_writer: Callable[[str], Path])
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
 
 def test_override_guard_click_group(mock_script_writer: Callable[[str], Path]) -> None:
@@ -475,8 +453,7 @@ def test_override_guard_click_group(mock_script_writer: Callable[[str], Path]) -
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
                                                                                                     \n\
@@ -485,8 +462,7 @@ def test_override_guard_click_group(mock_script_writer: Callable[[str], Path]) -
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
 
 def test_override_guard_disabled_click_from_rich_click(mock_script_writer: Callable[[str], Path]) -> None:
@@ -558,8 +534,7 @@ def test_override_guard_enabled_click_from_rich_click(mock_script_writer: Callab
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
                                                                                                     \n\
@@ -568,8 +543,7 @@ def test_override_guard_enabled_click_from_rich_click(mock_script_writer: Callab
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
 
 
 @pytest.mark.skipif(
@@ -577,8 +551,7 @@ def test_override_guard_enabled_click_from_rich_click(mock_script_writer: Callab
     reason="Click >=8.4.0 renders --bad-input wrapped in single quotes",
 )
 def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
-    mock_script_writer(
-        '''
+    mock_script_writer('''
         import click
 
         @click.group("foo")
@@ -588,16 +561,14 @@ def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
         @foo.command("bar")
         def bar():
             """bar command"""
-        '''
-    )
+        ''')
 
     res_grp = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:foo", "--bad-input"],
     )
     assert res_grp.returncode == 2
     assert res_grp.stdout.decode() == ""
-    assert res_grp.stderr.decode() == snapshot(
-        """\
+    assert res_grp.stderr.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
                                                                                                     \n\
@@ -606,8 +577,7 @@ def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
 │ No such option: --bad-input                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                     \n\
-"""
-    )
+""")
 
     res_cmd = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:foo", "bar", "--bad-input"],
@@ -615,8 +585,7 @@ def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
     assert res_cmd.returncode == 2
 
     assert res_grp.stdout.decode() == ""
-    assert res_grp.stderr.decode() == snapshot(
-        """\
+    assert res_grp.stderr.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
                                                                                                     \n\
@@ -625,8 +594,7 @@ def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
 │ No such option: --bad-input                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                     \n\
-"""
-    )
+""")
 
 
 @pytest.mark.skipif(
@@ -634,8 +602,7 @@ def test_error_to_stderr(mock_script_writer: Callable[[str], Path]) -> None:
     reason="Click <8.4.0 renders --bad-input without single quotes",
 )
 def test_error_to_stderr_click_8_4(mock_script_writer: Callable[[str], Path]) -> None:
-    mock_script_writer(
-        '''
+    mock_script_writer('''
         import click
 
         @click.group("foo")
@@ -645,16 +612,14 @@ def test_error_to_stderr_click_8_4(mock_script_writer: Callable[[str], Path]) ->
         @foo.command("bar")
         def bar():
             """bar command"""
-        '''
-    )
+        ''')
 
     res_grp = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:foo", "--bad-input"],
     )
     assert res_grp.returncode == 2
     assert res_grp.stdout.decode() == ""
-    assert res_grp.stderr.decode() == snapshot(
-        """\
+    assert res_grp.stderr.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
                                                                                                     \n\
@@ -663,8 +628,7 @@ def test_error_to_stderr_click_8_4(mock_script_writer: Callable[[str], Path]) ->
 │ No such option '--bad-input'.                                                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                     \n\
-"""
-    )
+""")
 
     res_cmd = run_as_subprocess(
         [sys.executable, "-m", "src.rich_click", "mymodule:foo", "bar", "--bad-input"],
@@ -672,8 +636,7 @@ def test_error_to_stderr_click_8_4(mock_script_writer: Callable[[str], Path]) ->
     assert res_cmd.returncode == 2
 
     assert res_grp.stdout.decode() == ""
-    assert res_grp.stderr.decode() == snapshot(
-        """\
+    assert res_grp.stderr.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS] COMMAND [ARGS]...                               \n\
                                                                                                     \n\
@@ -682,8 +645,7 @@ def test_error_to_stderr_click_8_4(mock_script_writer: Callable[[str], Path]) ->
 │ No such option '--bad-input'.                                                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                     \n\
-"""
-    )
+""")
 
 
 rich_version = packaging.version.parse(version("rich"))
@@ -706,8 +668,7 @@ def test_cli_output_html(mock_script_writer: Callable[[str], Path]) -> None:
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
 <!DOCTYPE html>
 <html>
 <head>
@@ -732,8 +693,7 @@ body {
 </code></pre>
 </body>
 </html>
-"""
-    )
+""")
 
 
 def test_cli_output_svg(mock_script_writer: Callable[[str], Path]) -> None:
@@ -752,8 +712,7 @@ def test_cli_output_svg(mock_script_writer: Callable[[str], Path]) -> None:
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
 <svg class="rich-terminal" viewBox="0 0 1238 245.2" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
@@ -844,8 +803,7 @@ def test_cli_output_svg(mock_script_writer: Callable[[str], Path]) -> None:
     </g>
     </g>
 </svg>
-"""
-    )
+""")
 
 
 def test_cli_output_text(mock_script_writer: Callable[[str], Path]) -> None:
@@ -866,8 +824,7 @@ def test_cli_output_text(mock_script_writer: Callable[[str], Path]) -> None:
     )
     assert res.returncode == 0
 
-    assert res.stdout.decode() == snapshot(
-        """\
+    assert res.stdout.decode() == snapshot("""\
                                                                                                     \n\
  Usage: python -m src.rich_click.mymodule [OPTIONS]                                                 \n\
                                                                                                     \n\
@@ -876,5 +833,4 @@ def test_cli_output_text(mock_script_writer: Callable[[str], Path]) -> None:
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help  Show this message and exit.                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")

--- a/tests/typer_help/test_typer_markdown.py
+++ b/tests/typer_help/test_typer_markdown.py
@@ -16,8 +16,7 @@ def cli(patch_typer: None) -> typer.Typer:
 def test_typer_markdown(typer_cli_runner: CliRunner, cli: typer.Typer) -> None:
     result = typer_cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
                                                                                                     \n\
  Usage: root [OPTIONS] COMMAND [ARGS]...                                                            \n\
                                                                                                     \n\
@@ -35,8 +34,7 @@ def test_typer_markdown(typer_cli_runner: CliRunner, cli: typer.Typer) -> None:
 │ help    Get help with the system. ❓                                                             │
 │ report  Report an issue. 🐛                                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -45,8 +43,7 @@ def test_typer_markdown_with_theme(typer_cli_runner: CliRunner, cli: typer.Typer
     rc.OPTIONS_PANEL_TITLE = "Custom Panel"
     result = typer_cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
  Usage: root [OPTIONS] COMMAND [ARGS]...                                                            \n\
                                                                                                     \n\
  ═ Custom Panel ═══════════════════════════════════════════════════════════════════════════════════ \n\
@@ -63,6 +60,5 @@ def test_typer_markdown_with_theme(typer_cli_runner: CliRunner, cli: typer.Typer
  help    Get help with the system. ❓                                                               \n\
  report  Report an issue. 🐛                                                                        \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/typer_help/test_typer_rich_panels.py
+++ b/tests/typer_help/test_typer_rich_panels.py
@@ -17,8 +17,7 @@ def test_typer_rich_panels(typer_cli_runner: CliRunner, cli: typer.Typer) -> Non
     rc.THEME = "nu"
     result = typer_cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
  Usage: root [OPTIONS] COMMAND [ARGS]...                                                            \n\
                                                                                                     \n\
  ═ Options ════════════════════════════════════════════════════════════════════════════════════════ \n\
@@ -39,8 +38,7 @@ def test_typer_rich_panels(typer_cli_runner: CliRunner, cli: typer.Typer) -> Non
  help    Get help with the system. ❓                                                               \n\
  report  Report an issue. 🐛                                                                        \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -48,8 +46,7 @@ def test_typer_rich_panels_subcommand(typer_cli_runner: CliRunner, cli: typer.Ty
     rc.THEME = "nu"
     result = typer_cli_runner.invoke(cli, ["create", "--help"])
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
  Usage: root create [OPTIONS] USERNAME                                                              \n\
                                                                                                     \n\
  Create a new user. ✨                                                                              \n\
@@ -65,6 +62,5 @@ def test_typer_rich_panels_subcommand(typer_cli_runner: CliRunner, cli: typer.Ty
  --verbose/--no-verbose  (Default: no-verbose)                                                      \n\
  --debug/--no-debug      (Default: no-debug)                                                        \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")

--- a/tests/typer_help/test_typer_types.py
+++ b/tests/typer_help/test_typer_types.py
@@ -19,8 +19,7 @@ def test_typer_types_help(typer_cli_runner: CliRunner, cli: typer.Typer) -> None
     rc.THEME = "nu"
     result = typer_cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
  Usage: cli [OPTIONS] ID                                                                            \n\
                                                                                                     \n\
  ═ Arguments ══════════════════════════════════════════════════════════════════════════════════════ \n\
@@ -38,8 +37,7 @@ def test_typer_types_help(typer_cli_runner: CliRunner, cli: typer.Typer) -> None
  --log-level         [debug|info|warn|error] (Default: info)                                        \n\
  --color/--no-color  (Default: color)                                                               \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")
 
 
@@ -48,8 +46,7 @@ def test_typer_types_help_renamed_default_panel(typer_cli_runner: CliRunner, cli
     rc.OPTIONS_PANEL_TITLE = "Custom Panel"
     result = typer_cli_runner.invoke(cli, "--help")
     assert result.exit_code == 0
-    assert result.stdout == snapshot(
-        """\
+    assert result.stdout == snapshot("""\
  Usage: cli [OPTIONS] ID                                                                            \n\
                                                                                                     \n\
  ═ Arguments ══════════════════════════════════════════════════════════════════════════════════════ \n\
@@ -67,6 +64,5 @@ def test_typer_types_help_renamed_default_panel(typer_cli_runner: CliRunner, cli
  --log-level         [debug|info|warn|error] (Default: info)                                        \n\
  --color/--no-color  (Default: color)                                                               \n\
                                                                                                     \n\
-"""
-    )
+""")
     assert result.stderr == snapshot("")


### PR DESCRIPTION
### Fix mypy breakage

Latest version of mypy broke some of our type checks in the pre-commit. I made the couple minor changes to address that. I also fixed an issue in `pyproject.toml` that made it more likely the CI and local were out of sync.

### pyproject.toml: Swap deps to groups

We were using "optional dependencies" for dev and docs, but what we should be using is groups.

The main difference is optional deps are saved as package metadata; groups are not and are solely for the local environment. Groups are the correct way to do this.

### Swap to prek over pre-commit

I've had my eye on prek for a bit. https://github.com/j178/prek It's become quite popular, and I've been using at work the past 6 or so months. It's a little better than pre-commit in my experience.

### Swap to `ruff format` + remove Black because of ruff conflicts

Once I ran `prek update --freeze`, black and ruff started fighting with each other. To fix, I removed Black and added `ruff format`.

All the other changes are the result of `ruff format`.