### PR TITLE
Move docs off MkDocs onto ProperDocs, upgrade Material to 9.7, fix broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Development tooling only; no changes to the library itself.
 - Dev and docs requirements moved from optional dependencies to [dependency groups](https://peps.python.org/pep-0735/), so they are no longer published as package metadata. Install them with `uv sync --all-groups`.
 - Switched from [pre-commit](https://pre-commit.com/) to [prek](https://github.com/j178/prek), and replaced `.pre-commit-config.yaml` with `prek.toml`. Contributors should re-run `prek install` to replace their old git hook.
 - Replaced Black with `ruff format`, which resolves the formatting conflicts between the two.
+- Docs are now built with [ProperDocs](https://properdocs.org/), a drop-in fork of MkDocs 1.x, as MkDocs itself is unmaintained. `mike` picks it up automatically, so the deploy flow is unchanged.
+- Upgraded Material for MkDocs from 9.5 to 9.7, the final feature release, which folds in the former Insiders features.
+- Dropped the unused `gh-admonitions` plugin.
 
 ## Version 1.9.8 (2026-05-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Development tooling only; no changes to the library itself.
 - Replaced Black with `ruff format`, which resolves the formatting conflicts between the two.
 - Docs are now built with [ProperDocs](https://properdocs.org/), a drop-in fork of MkDocs 1.x, as MkDocs itself is unmaintained. `mike` picks it up automatically, so the deploy flow is unchanged.
 - Upgraded Material for MkDocs from 9.5 to 9.7, the final feature release, which folds in the former Insiders features.
-- Dropped the unused `gh-admonitions` plugin.
 - Fixed some broken docs links, and enabled `strict` mode so that broken links and anchors fail the docs build.
 
 ## Version 1.9.8 (2026-05-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Development tooling only; no changes to the library itself.
 - Docs are now built with [ProperDocs](https://properdocs.org/), a drop-in fork of MkDocs 1.x, as MkDocs itself is unmaintained. `mike` picks it up automatically, so the deploy flow is unchanged.
 - Upgraded Material for MkDocs from 9.5 to 9.7, the final feature release, which folds in the former Insiders features.
 - Dropped the unused `gh-admonitions` plugin.
+- Fixed some broken docs links, and enabled `strict` mode so that broken links and anchors fail the docs build.
 
 ## Version 1.9.8 (2026-05-28)
 

--- a/docs/documentation/comparison_of_click_and_rich_click.md
+++ b/docs/documentation/comparison_of_click_and_rich_click.md
@@ -140,6 +140,6 @@ Below is a side-by-side comparison of Click and Rich implementations of echos an
         """My application"""
         ...
     ```
-    More information about this is described in [the **Panels** docs](panels/panels.md).
+    More information about this is described in [the **Panels** docs](panels/overview.md).
 - **rich-click** has a configuration object, **`RichHelpConfiguration()`**, that allows for control over how **rich-click** help text renders, so you are not locked into the defaults. More information about this is described in [the **Configuration** docs](configuration.md).
 - **rich-click** comes with a CLI tool that allows you to convert regular Click CLIs into **rich-click** CLIs, and also lets you render your **rich-click** CLI help text as HTML, SVG, JSON, and trees. More information about this is described in [the **rich-click CLI** docs](rich_click_cli.md), or you can run **`rich-click --help`** to view the CLI.

--- a/docs/documentation/panels/overview.md
+++ b/docs/documentation/panels/overview.md
@@ -3,7 +3,7 @@
 **rich-click** lets you configure grouping and sorting of command options and subcommands.
 The containers which contain grouped options and subcommands are called panels:
 
-![](../../../images/panels.svg)
+![](../../images/panels.svg)
 
 By default, `RichCommand`s have a single panel for options named "Options", and `RichGroup`s have an additional panel for commands named "Commands".
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,7 +90,6 @@ plugins:
   - search
   - blog
   - include-markdown
-  - gh-admonitions
   - social:
       cards_layout_options:
         font_family: Kode Mono

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: rich-click
+strict: true
 repo_name: ewels/rich-click
 repo_url: https://github.com/ewels/rich-click
 site_url: https://ewels.github.io/rich-click/
@@ -63,6 +64,13 @@ nav:
 # Deliberately unlisted above while still under construction.
 not_in_nav: |
   /documentation/structure.md
+
+# Both of these default to `info`, which means broken anchors and malformed
+# internal links pass silently. Raised to `warn` so `strict` catches them.
+validation:
+  links:
+    anchors: warn
+    unrecognized_links: warn
 
 markdown_extensions:
   - toc:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,9 @@ plugins:
   - search
   - blog
   - include-markdown
+  # Must run after include-markdown: the alerts it renders live in the root
+  # CHANGELOG.md and CONTRIBUTING.md, which are pulled in by that plugin.
+  - gh-admonitions
   - social:
       cards_layout_options:
         font_family: Kode Mono

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,10 @@ nav:
   - Changelog: changelog.md
   - Contributing: contributing.md
 
+# Deliberately unlisted above while still under construction.
+not_in_nav: |
+  /documentation/structure.md
+
 markdown_extensions:
   - toc:
       permalink: true
@@ -111,7 +115,7 @@ plugins:
       canonical_version: latest
   - redirects:
       redirect_maps:
-        'documentation/groups_and_sorting.md': 'documentation/panels.md'
+        'documentation/groups_and_sorting.md': 'documentation/panels/overview.md'
         'documentation/formatting_and_styles.md': 'documentation/text_markup_and_formatting.md'
 
 extra_css:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,16 +62,20 @@ dev = [
 ]
 docs = [
     "markdown-include>=0.8.1",
-    "mike>=2.1.3",
-    "mkdocs>=1.6.1",
-    "mkdocs-github-admonitions-plugin>=0.1.1",
+    "mike>=2.2",                             # 2.2 is the first release that detects ProperDocs
+    # MkDocs itself is abandoned upstream and its planned v2 drops support for
+    # existing themes, plugins and config files. ProperDocs is a drop-in fork of
+    # 1.x; `mike` picks it up automatically when installed. MkDocs is still
+    # pulled in transitively (mkdocs-material, mike), so cap it below v2.
+    "mkdocs>=1.6.1,<2",
     "mkdocs-glightbox>=0.4",
     "mkdocs-include-markdown-plugin>=7.1.7",
-    "mkdocs-material[imaging]~=9.5.18",
+    "mkdocs-material[imaging]~=9.7.7",
     "mkdocs-material-extensions>=1.3.1",
     "mkdocs-redirects>=1.2.2",
     "mkdocs-rss-plugin>=1.15",
     "mkdocstrings[python]>=0.26.1",
+    "properdocs>=1.6.7",
     "rich-codex>=1.2.11",
     "typer>=0.15,<0.26",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ docs = [
     # 1.x; `mike` picks it up automatically when installed. MkDocs is still
     # pulled in transitively (mkdocs-material, mike), so cap it below v2.
     "mkdocs>=1.6.1,<2",
+    "mkdocs-github-admonitions-plugin>=0.1.1",
     "mkdocs-glightbox>=0.4",
     "mkdocs-include-markdown-plugin>=7.1.7",
     "mkdocs-material[imaging]~=9.7.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
 ]
 docs = [
     "markdown-include>=0.8.1",
-    "mike>=2.2",                             # 2.2 is the first release that detects ProperDocs
+    "mike>=2.2",                               # 2.2 is the first release that detects ProperDocs
     # MkDocs itself is abandoned upstream and its planned v2 drops support for
     # existing themes, plugins and config files. ProperDocs is a drop-in fork of
     # 1.x; `mike` picks it up automatically when installed. MkDocs is still


### PR DESCRIPTION
MkDocs has been unmaintained since August 2024 and its planned v2 drops support for existing themes, plugins and config files — and our `mkdocs` pin had no upper bound, so a v2 release to PyPI would have broken the docs build outright. Material for MkDocs is also [EOL on 5 November 2026](https://github.com/squidfunk/mkdocs-material/issues/8523).

This swaps the build engine for [ProperDocs](https://properdocs.org/) (a drop-in fork of MkDocs 1.x), bumps Material 9.5 → 9.7, fixes some long-standing broken links, and turns on `strict` so links can't rot again. The site looks and works exactly as before — verified page by page. The eventual move to [Zensical](https://zensical.org/) is deliberately not attempted here.

Two things worth a second opinion, both covered below: the `mike` floor bump, and whether `strict` is too sharp an edge.

<details>
<summary>Details</summary>

## Changes

### Build engine → ProperDocs

[ProperDocs](https://properdocs.org/) is a fork of MkDocs 1.x committed to no breaking changes. Its output is byte-identical to MkDocs apart from the `<meta name="generator">` tag, and `mike` detects and drives it automatically, so `docs/_deploy.py` and `.github/workflows/build-docs.yml` need no changes at all.

One gotcha worth flagging for review: **`mike` only gained ProperDocs detection in 2.2**. The old `mike>=2.1.3` floor would have let a resolve land on 2.1.3 and silently keep building through MkDocs, so the floor is bumped. `mkdocs` is still pulled in transitively by mkdocs-material and mike, so it is capped below v2.

### Material for MkDocs 9.5 → 9.7

The final feature release, which folds in the features that used to be exclusive to Insiders. Builds clean with no config changes. Rendered output is unchanged apart from asset hashes and a FontAwesome 6 → 7 bump.

### Fixed broken links

`e608f63` split `documentation/panels.md` into `panels/{overview,tips,advanced}.md` and left two references behind:

- The comparison page linked to `panels/panels.md`, a dead link.
- The `groups_and_sorting.md` redirect pointed at `documentation/panels.md`. Because the target did not exist, mkdocs-redirects skipped the page entirely, so the old v1.8 URL `/documentation/groups_and_sorting/` was returning a hard 404 rather than redirecting. It resolves again now.

Also fixed the panels overview image, which had one `../` too many and so never rendered, and marked the under-construction `documentation/structure.md` as `not_in_nav` (it is still published, exactly as before).

### `strict: true`

Nothing stopped those links from rotting again. `strict` turns any warning into a build failure, including plugin warnings — which matters, because the broken redirect target was reported by mkdocs-redirects rather than by the link checker, so no `validation:` setting would have caught it.

`validation.links.anchors` and `unrecognized_links` default to `info`, meaning broken anchors pass silently; both are raised to `warn` so `strict` acts on them. Neither surfaces any existing problem.

**Trade-off worth a second opinion:** `strict` is indiscriminate. If the social-cards, rss or glightbox plugins ever emit a warning, `main` stops publishing docs until someone fixes it. Happy to drop the `strict` commit if that is too sharp an edge.

## Testing

Built `origin/main` with its own toolchain (MkDocs 1.6.1, Material 9.5.50) and this branch with the new one, then text-diffed **every** page:

- No page present on `main` is missing here. One page is added: the restored `groups_and_sorting` redirect.
- Across all 30 shared pages, the only text difference is the new changelog entries this PR adds.
- `mike deploy --update-aliases 1.9 latest` in a scratch clone: builds via ProperDocs, writes to `gh-pages`, `mike list` reports `1.9 [latest]`, `versions.json` correct, version-selector markup unchanged.
- Reintroduced each of the three link bugs in turn, plus a link to a non-existent anchor: each now aborts the build, including through the `mike deploy` path that CI uses.
- `prek run -a` clean locally (minus `actionlint`, which needs a Go download, and `mypy`, which needs project deps — both pass in CI).

**Not verified:** social card generation. The sandbox blocks `fonts.google.com`, which the plugin fetches Kode Mono from, so the comparison builds ran without it. The plugin loads fine under ProperDocs — it gets as far as the font fetch — but the first CI run is what will confirm the cards still render. Worth watching on merge, particularly now that `strict` would turn a warning from it into a failed deploy.

## A correction, for the record

An earlier revision of this branch dropped `mkdocs-github-admonitions-plugin` as unused. That was wrong, and `70de252` puts it back. `docs/changelog.md` and `docs/contributing.md` are thin wrappers that pull in the root `CHANGELOG.md` and `CONTRIBUTING.md` via include-markdown, and those two files contain five GitHub-style alerts that rendered as plain blockquotes with a literal `[!WARNING]` in the body text without the plugin. The net change to that plugin's config in this PR is now just a comment explaining that it has to run after include-markdown.

## Why not Zensical

Zensical is the official successor and where this should eventually land, but at 0.0.53 it is not ready for this project specifically. Building these docs with it: the `editor.html` override fails outright (minijinja has no `.items()` on maps), the blog plugin is unsupported so every existing post URL changes and archive/category pages vanish, RSS and redirects produce no output, and `include-markdown` markers pass through raw (the changelog page drops from 74 KB to 21 KB). Worth revisiting once blog support lands.

</details>