### PR TITLE
Fix ctx.forward(rich_cmd) TypeError after patch()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed `ctx.forward(rich_cmd)` raising `TypeError` after `patch()` replaced `click.Command` with a subclass. [[#338](https://github.com/ewels/rich-click/issues/338)]
 - Dropped support for Python 3.8 and 3.9; the minimum supported version is now Python 3.10.
 - Modernised the codebase to Python 3.10+ syntax (PEP 604 unions, built-in generics) and removed version-conditional shims for Python <3.10.
 - Dev and docs requirements moved from optional dependencies to [dependency groups](https://peps.python.org/pep-0735/), so they are no longer published as package metadata. Install them with `uv sync --all-groups`.

--- a/src/rich_click/patch.py
+++ b/src/rich_click/patch.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 # ruff: noqa: D103
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from click import Argument, Command, Context, Group, Option
+from click import Argument, Command, CommandCollection, Context, Group, Option
 
 from rich_click.decorators import command as _rich_command
 from rich_click.decorators import group as _rich_group
@@ -241,13 +241,27 @@ class PatchMeta(type):
             elif name == "TyperArgument":
                 _patch_typer_argument(cls)  # type: ignore[arg-type]
 
+    def __instancecheck__(cls, instance: Any) -> bool:
+        if type.__instancecheck__(cls, instance):
+            return True
+        # patch() replaces click.Command with a subclass. Existing RichCommand
+        # (and original click.Command) instances are parents of that subclass,
+        # so a normal isinstance() check fails and ctx.forward(rich_cmd) raises
+        # TypeError("Callback is not a command."). Recognize the original type
+        # on this class only — not inherited — so Typer patches stay narrow.
+        orig = cls.__dict__.get("_rich_click_isinstance_base")
+        if orig is not None:
+            return isinstance(instance, orig)
+        return False
+
 
 # Click >=8.4.0 Parameters subclass ABC.
 class PatchMetaAbc(PatchMeta, ABCMeta): ...
 
 
 class _PatchedRichCommand(RichCommand, metaclass=PatchMeta):
-    pass
+    # Original click.Command captured at import time (before patch()).
+    _rich_click_isinstance_base: ClassVar[type[Any]] = Command
 
 
 class _PatchedRichMultiCommand(RichMultiCommand, _PatchedRichCommand):
@@ -255,11 +269,11 @@ class _PatchedRichMultiCommand(RichMultiCommand, _PatchedRichCommand):
 
 
 class _PatchedRichCommandCollection(RichCommandCollection, _PatchedRichCommand):
-    pass
+    _rich_click_isinstance_base = CommandCollection
 
 
 class _PatchedRichGroup(RichGroup, _PatchedRichCommand):
-    pass
+    _rich_click_isinstance_base = Group
 
 
 # Options and Arguments don't need to be patched for base click CLIs.
@@ -267,11 +281,11 @@ class _PatchedRichGroup(RichGroup, _PatchedRichCommand):
 
 
 class _PatchedOption(Option, metaclass=PatchMetaAbc):
-    pass
+    _rich_click_isinstance_base = Option
 
 
 class _PatchedArgument(Argument, metaclass=PatchMetaAbc):
-    pass
+    _rich_click_isinstance_base = Argument
 
 
 def rich_command(*args, **kwargs):  # type: ignore[no-untyped-def]

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,0 +1,91 @@
+"""Tests for rich_click.patch.patch()."""
+
+from __future__ import annotations
+
+import sys
+
+import rich_click
+from rich_click.patch import _PatchedRichCommand, _PatchedRichGroup
+from tests.conftest import run_as_subprocess
+
+
+def test_patched_command_isinstance_accepts_rich_command() -> None:
+    """RichCommand is a parent of _PatchedRichCommand; isinstance must still match."""
+
+    @rich_click.command()
+    def rich_cmd() -> None:
+        """Rich command."""
+
+    assert isinstance(rich_cmd, _PatchedRichCommand)
+    assert not isinstance("not-a-command", _PatchedRichCommand)
+
+
+def test_patched_group_isinstance_accepts_rich_group() -> None:
+    @rich_click.group()
+    def rich_grp() -> None:
+        """Rich group."""
+
+    assert isinstance(rich_grp, _PatchedRichGroup)
+    assert isinstance(rich_grp, _PatchedRichCommand)
+    assert not isinstance(object(), _PatchedRichGroup)
+
+
+def test_forward_rich_command_after_patch() -> None:
+    """ctx.forward(rich_cmd) must work after patch() replaces click.Command (#338)."""
+    script = """
+import click
+import rich_click
+from click.testing import CliRunner
+from rich_click.patch import patch
+
+@rich_click.command()
+@rich_click.option("--name", default="world")
+def rich_cmd(name):
+    print(f"hello {name}")
+
+patch()
+
+@click.command()
+@click.option("--name", default="world")
+@click.pass_context
+def cli(ctx, name):
+    ctx.forward(rich_cmd)
+
+res = CliRunner().invoke(cli, ["--name", "sea"])
+assert res.exit_code == 0, repr(res.exception)
+assert res.output == "hello sea\\n"
+print("OK")
+"""
+    res = run_as_subprocess([sys.executable, "-c", script])
+    assert res.returncode == 0, res.stderr.decode() + res.stdout.decode()
+    assert res.stdout.decode().strip() == "OK"
+
+
+def test_invoke_rich_command_after_patch() -> None:
+    """ctx.invoke(rich_cmd) uses the same Command isinstance check as forward."""
+    script = """
+import click
+import rich_click
+from click.testing import CliRunner
+from rich_click.patch import patch
+
+@rich_click.command()
+@rich_click.option("--name", default="world")
+def rich_cmd(name):
+    print(f"hello {name}")
+
+patch()
+
+@click.command()
+@click.pass_context
+def cli(ctx):
+    ctx.invoke(rich_cmd, name="sea")
+
+res = CliRunner().invoke(cli)
+assert res.exit_code == 0, repr(res.exception)
+assert res.output == "hello sea\\n"
+print("OK")
+"""
+    res = run_as_subprocess([sys.executable, "-c", script])
+    assert res.returncode == 0, res.stderr.decode() + res.stdout.decode()
+    assert res.stdout.decode().strip() == "OK"


### PR DESCRIPTION
## Summary

Fixes #338.

`patch()` replaces `click.Command` / `click.core.Command` with `_PatchedRichCommand`, a *subclass* of `RichCommand`. A command created with `@rich_click.command()` is a `RichCommand` instance — a *parent* of that subclass — so after patching:

```python
isinstance(rich_cmd, click.Command)  # False
ctx.forward(rich_cmd)                # TypeError: Callback is not a command.
```

Click's `Context.forward` / `Context.invoke` both gate on that `isinstance` check.

This teaches the patched types (via `PatchMeta.__instancecheck__`) to also accept instances of the original `Command` / `Group` / `CommandCollection` classes captured at import time. The override is stored on each patched class and read from `cls.__dict__` so it is not inherited by Typer patches.

## Test plan

- [x] Reproduced on current `main`: `ctx.forward(rich_cmd)` after `patch()` raises `TypeError: Callback is not a command.`
- [x] After this change the same script prints `hello sea` and exits 0
- [x] `pytest tests/test_patch.py` — 4 passed (isinstance for command/group; `forward` and `invoke` after `patch()` in a subprocess)