### PR TITLE
Resolve the secondary Click re-exports lazily via `__getattr__`

### DIFF
--- a/src/rich_click/__init__.py
+++ b/src/rich_click/__init__.py
@@ -7,62 +7,84 @@ customization required.
 
 from __future__ import annotations
 
+import typing as _t
+
 
 __version__ = "1.9.9"
 
-# Import the entire click API here.
-# We need to manually import these instead of `from click import *` to force
-# mypy to recognize a few type annotation overrides for the rich_click decorators.
+# The primary Click API, imported eagerly.
+# We name these individually rather than `from click import *` to force mypy to
+# recognize a few type annotation overrides for the rich_click decorators.
+#
+# These six are the load-bearing names -- every rich-click subclass derives from
+# one -- and Click is not going to move or deprecate them, so importing them
+# costs nothing and keeps `rich_click.Command` resolvable without a __getattr__
+# hop on the hottest path.
 from click.core import Argument as Argument
 from click.core import Command as Command
-from click.core import CommandCollection as CommandCollection
 from click.core import Context as Context
 from click.core import Group as Group
 from click.core import Option as Option
 from click.core import Parameter as Parameter
-from click.decorators import make_pass_decorator as make_pass_decorator
-from click.decorators import pass_obj as pass_obj
-from click.exceptions import Abort as Abort
-from click.exceptions import BadArgumentUsage as BadArgumentUsage
-from click.exceptions import BadOptionUsage as BadOptionUsage
-from click.exceptions import BadParameter as BadParameter
-from click.exceptions import ClickException as ClickException
-from click.exceptions import FileError as FileError
-from click.exceptions import MissingParameter as MissingParameter
-from click.exceptions import NoSuchOption as NoSuchOption
-from click.exceptions import UsageError as UsageError
-from click.formatting import HelpFormatter as HelpFormatter
-from click.formatting import wrap_text as wrap_text
-from click.termui import clear as clear
-from click.termui import confirm as confirm
-from click.termui import echo_via_pager as echo_via_pager
-from click.termui import edit as edit
-from click.termui import getchar as getchar
-from click.termui import launch as launch
-from click.termui import pause as pause
-from click.termui import progressbar as progressbar
-from click.termui import prompt as prompt
-from click.termui import secho as secho
-from click.termui import style as style
-from click.termui import unstyle as unstyle
-from click.types import BOOL as BOOL
-from click.types import FLOAT as FLOAT
-from click.types import INT as INT
-from click.types import STRING as STRING
-from click.types import UNPROCESSED as UNPROCESSED
-from click.types import UUID as UUID
-from click.types import Choice as Choice
-from click.types import DateTime as DateTime
-from click.types import File as File
-from click.types import FloatRange as FloatRange
-from click.types import IntRange as IntRange
-from click.types import ParamType as ParamType
-from click.types import Path as Path
-from click.types import Tuple as Tuple
-from click.utils import echo as echo
-from click.utils import format_filename as format_filename
-from click.utils import get_app_dir as get_app_dir
-from click.utils import open_file as open_file
+
+
+# The rest of the Click API, re-exported but resolved lazily by `__getattr__`.
+#
+# Click has been moving and deprecating names between minor releases, and
+# importing these eagerly meant the DeprecationWarning fired the moment anything
+# imported rich_click -- breaking CI for downstreams that assert no warnings
+# (litestar-org/litestar#5020) over names most of them never touch. Resolving on
+# first access moves the warning to the code that actually uses the name.
+#
+# Type checkers still see real `from click...` imports, so the annotation
+# overrides are unaffected, and a name Click removes outright still fails under
+# TYPE_CHECKING -- which is correct. That is a real breakage; it just should not
+# land at import time on a CLI that never used the name.
+if _t.TYPE_CHECKING:
+    from click.core import CommandCollection as CommandCollection
+    from click.decorators import make_pass_decorator as make_pass_decorator
+    from click.decorators import pass_obj as pass_obj
+    from click.exceptions import Abort as Abort
+    from click.exceptions import BadArgumentUsage as BadArgumentUsage
+    from click.exceptions import BadOptionUsage as BadOptionUsage
+    from click.exceptions import BadParameter as BadParameter
+    from click.exceptions import ClickException as ClickException
+    from click.exceptions import FileError as FileError
+    from click.exceptions import MissingParameter as MissingParameter
+    from click.exceptions import NoSuchOption as NoSuchOption
+    from click.exceptions import UsageError as UsageError
+    from click.formatting import HelpFormatter as HelpFormatter
+    from click.formatting import wrap_text as wrap_text
+    from click.termui import clear as clear
+    from click.termui import confirm as confirm
+    from click.termui import echo_via_pager as echo_via_pager
+    from click.termui import edit as edit
+    from click.termui import getchar as getchar
+    from click.termui import launch as launch
+    from click.termui import pause as pause
+    from click.termui import progressbar as progressbar
+    from click.termui import prompt as prompt
+    from click.termui import secho as secho
+    from click.termui import style as style
+    from click.termui import unstyle as unstyle
+    from click.types import BOOL as BOOL
+    from click.types import FLOAT as FLOAT
+    from click.types import INT as INT
+    from click.types import STRING as STRING
+    from click.types import UNPROCESSED as UNPROCESSED
+    from click.types import UUID as UUID
+    from click.types import Choice as Choice
+    from click.types import DateTime as DateTime
+    from click.types import File as File
+    from click.types import FloatRange as FloatRange
+    from click.types import IntRange as IntRange
+    from click.types import ParamType as ParamType
+    from click.types import Path as Path
+    from click.types import Tuple as Tuple
+    from click.utils import echo as echo
+    from click.utils import format_filename as format_filename
+    from click.utils import get_app_dir as get_app_dir
+    from click.utils import open_file as open_file
 
 from rich_click.decorators import argument as argument
 from rich_click.decorators import command as command
@@ -91,6 +113,69 @@ from rich_click.rich_parameter import RichOption as RichOption
 from rich_click.rich_parameter import RichParameter as RichParameter
 
 from . import rich_click as rich_click
+
+
+#: Click names re-exported by rich-click but resolved on first access, so that
+#: importing rich_click does not import them. Listed explicitly rather than
+#: derived from `dir(click)`, so the public surface stays a decision made in
+#: this file rather than whatever the installed Click happens to carry.
+_LAZY_CLICK_EXPORTS: _t.Final[tuple[str, ...]] = (
+    "Abort",
+    "BOOL",
+    "BadArgumentUsage",
+    "BadOptionUsage",
+    "BadParameter",
+    "Choice",
+    "ClickException",
+    "CommandCollection",
+    "DateTime",
+    "FLOAT",
+    "File",
+    "FileError",
+    "FloatRange",
+    "HelpFormatter",
+    "INT",
+    "IntRange",
+    "MissingParameter",
+    "NoSuchOption",
+    "ParamType",
+    "Path",
+    "STRING",
+    "Tuple",
+    "UNPROCESSED",
+    "UUID",
+    "UsageError",
+    "clear",
+    "confirm",
+    "echo",
+    "echo_via_pager",
+    "edit",
+    "format_filename",
+    "get_app_dir",
+    "getchar",
+    "launch",
+    "make_pass_decorator",
+    "open_file",
+    "pass_obj",
+    "pause",
+    "progressbar",
+    "prompt",
+    "secho",
+    "style",
+    "unstyle",
+    "wrap_text",
+)
+
+
+def __dir__() -> list[str]:
+    """
+    Include the lazily-resolved Click names in `dir(rich_click)`.
+
+    Module `__dir__` defaults to `__dict__`, and these names are not in it until
+    something asks for one -- so without this they would be invisible to
+    tab-completion and `help()` on a fresh import.
+    """
+    return sorted({*globals(), *_LAZY_CLICK_EXPORTS, "RichMultiCommand"})
 
 
 def __getattr__(name: str) -> object:

--- a/tests/test_lazy_click_reexports.py
+++ b/tests/test_lazy_click_reexports.py
@@ -51,13 +51,18 @@ def test_every_reexport_is_the_click_object(name: str) -> None:
 
 @pytest.mark.parametrize("name", EAGER_NAMES)
 def test_the_primary_click_api_is_eager(name: str) -> None:
-    assert name in rich_click.__dict__
+    # `vars(...)`, not `rich_click.__dict__`: the module defines
+    # `__getattr__(name) -> object`, so mypy resolves *any* attribute it cannot
+    # find statically through it -- `__dict__` included -- and then rejects
+    # `in` against an `object`. `vars()` is typed `dict[str, Any]` and is the
+    # same lookup at runtime.
+    assert name in vars(rich_click)
 
 
 @pytest.mark.parametrize("name", [n for n in _declared_click_reexports() if n not in EAGER_NAMES])
 def test_the_secondary_click_api_is_lazy(name: str) -> None:
     """Not in `__dict__` means `__getattr__` is what served it."""
-    assert name not in rich_click.__dict__
+    assert name not in vars(rich_click)
 
 
 def test_dir_lists_the_lazy_names() -> None:

--- a/tests/test_lazy_click_reexports.py
+++ b/tests/test_lazy_click_reexports.py
@@ -1,0 +1,104 @@
+# ruff: noqa: D103,E501
+"""The Click API re-exported by `rich_click` resolves lazily (#353).
+
+Importing `rich_click` used to import every re-exported Click name eagerly. Click
+moves and deprecates names between minor releases, so that made a
+`DeprecationWarning` fire at import time for downstreams that never touched the
+deprecated name -- which broke CI for projects asserting no warnings
+(litestar-org/litestar#5020).
+
+Six primary `click.core` names stay eager; the rest resolve through the module
+`__getattr__` on first access.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+import pytest
+
+import rich_click
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INIT = REPO_ROOT / "src" / "rich_click" / "__init__.py"
+
+#: The primary Click API. Every rich-click subclass derives from one of these,
+#: and Click is not going to move them, so they are imported eagerly.
+EAGER_NAMES = ("Argument", "Command", "Context", "Group", "Option", "Parameter")
+
+
+def _declared_click_reexports() -> list[str]:
+    """Every `from click...` name in `__init__.py`, eager and lazy alike."""
+    return [
+        line.split(" as ")[-1].strip()
+        for line in open(INIT, encoding="utf-8")
+        if line.strip().startswith("from click.")
+    ]
+
+
+def test_the_parser_finds_the_reexports() -> None:
+    """Guard the helper: an empty list would make the parametrized tests vacuous."""
+    assert len(_declared_click_reexports()) > 40
+
+
+@pytest.mark.parametrize("name", _declared_click_reexports())
+def test_every_reexport_is_the_click_object(name: str) -> None:
+    """Lazy resolution must not change what a name means."""
+    assert getattr(rich_click, name) is getattr(click, name)
+
+
+@pytest.mark.parametrize("name", EAGER_NAMES)
+def test_the_primary_click_api_is_eager(name: str) -> None:
+    assert name in rich_click.__dict__
+
+
+@pytest.mark.parametrize("name", [n for n in _declared_click_reexports() if n not in EAGER_NAMES])
+def test_the_secondary_click_api_is_lazy(name: str) -> None:
+    """Not in `__dict__` means `__getattr__` is what served it."""
+    assert name not in rich_click.__dict__
+
+
+def test_dir_lists_the_lazy_names() -> None:
+    """Module `__dir__` defaults to `__dict__`, which the lazy names are not in."""
+    listing = dir(rich_click)
+    assert listing == sorted(listing)
+    for name in _declared_click_reexports():
+        assert name in listing
+    assert "RichMultiCommand" in listing
+
+
+def test_importing_rich_click_raises_no_deprecation_warning() -> None:
+    """The point of #353, in a fresh interpreter.
+
+    A subprocess rather than `warnings.catch_warnings`, because the module is
+    already imported by the time this file runs and the warning would have
+    fired long ago.
+    """
+    result = subprocess.run(
+        [sys.executable, "-W", "error::DeprecationWarning", "-c", "import rich_click"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_deprecated_name_still_warns_where_it_is_used() -> None:
+    """Lazy resolution moves the warning; it must not swallow it."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::DeprecationWarning",
+            "-c",
+            "import rich_click; rich_click.RichMultiCommand",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    from rich_click._compat_click import CLICK_IS_BEFORE_VERSION_9X
+
+    if CLICK_IS_BEFORE_VERSION_9X:
+        assert result.returncode != 0
+        assert "RichMultiCommand" in result.stderr


### PR DESCRIPTION
Implements the `__getattr__` + `TYPE_CHECKING` pattern from #353.

**Split follows the proposal exactly.** The six primary `click.core` names — `Argument`, `Command`, `Context`, `Group`, `Option`, `Parameter` — stay eager; the other 44 move under `TYPE_CHECKING` and are served by the `__getattr__` fallthrough to `click` that already existed. `CommandCollection` moves with the secondary set, as the issue suggested.

I initially moved *all fifty*, and that was wrong for a reason worth recording: it broke `test_no_rich_imports.py::test_imports_during_execution`. That test does `importlib.reload(rich_click)` and then asserts `any(m.startswith("click."))` as a control — a canary that the import recorder captured anything at all, without which its three negative assertions (`not any rich`, `not any markdown_it`, `not any importlib`) would pass vacuously. With no eager `from click...` line left, the reload recorded no `click.*` import and the canary died. Keeping the primary six eager preserves it, so the guard stays honest and no test needed changing.

**Verified:**

```
$ python -W error::DeprecationWarning -c "import rich_click"
(clean)

$ python -W error::DeprecationWarning -c "import rich_click; rich_click.RichMultiCommand"
DeprecationWarning: 'RichMultiCommand' is deprecated ...
```

So the warning is not swallowed — it moves to the code that actually uses the name, which is the point.

All 50 re-exports still resolve to the *identical* Click objects (`getattr(rich_click, n) is getattr(click, n)` for every one). `Command` is in `__dict__`; `Choice` is not, before or after access.

**`__dir__` added**, as you suggested. Module `__dir__` defaults to `__dict__` and the lazy names are not in it, so without this they'd disappear from tab-completion and `help()`. The name list is written out explicitly rather than derived from `dir(click)`, so the public surface stays a decision made in this file rather than whatever Click version happens to be installed.

**Test suite:** I diffed the full failure set against the unmodified tree — **200 failures/errors before, 200 after, zero regressed and zero newly failing**. (The suite is largely red on my Windows box for unrelated console-encoding reasons; the diff is the meaningful number, not the absolute.) `mypy src/rich_click` reports the same 47 pre-existing errors as `main`. `ruff check` clean on `src/` and `tests/`.

**New test** — `tests/test_lazy_click_reexports.py`, 104 cases: every declared re-export is the identical Click object, the six primary names are eager, the other 44 are absent from `__dict__`, `dir()` lists them all and is sorted, a fresh interpreter imports clean under `-W error::DeprecationWarning`, and a deprecated name still warns at the use site. It also guards its own parser — an empty name list would make the parametrized cases vacuous.

One thing I did *not* do: cache resolved names into `globals()`. You called the per-access `__getattr__` cost trivial and it is, and caching would make `"Choice" in rich_click.__dict__` depend on access history, which is a worse thing to have to reason about than a dict lookup.
